### PR TITLE
fix .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "content/kit"]
 	path = content/kit
-	url = git@github.com:sveltejs/kit
+	url = https://github.com/sveltejs/kit
+[submodule "packages/site-kit"]
+	path = packages/site-kit
+	url = https://github.com/sveltejs/site-kit


### PR DESCRIPTION
This fixes `.gitmodules` to include the module for `packages/site-kit`.

It also switches to using HTTPS to clone the submodules rather than SSH since it's more portable (I personally do not have my SSH key set up with GitHub), and since these repos don't need authentication to clone them anyway.

We should probably also update the readme to talk about Git submodules, but that can happen separately.