### PR TITLE
fix documentation edit links

### DIFF
--- a/sites/kit.svelte.dev/src/routes/docs/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/docs/index.svelte
@@ -1,6 +1,6 @@
 <script context="module">
 	export async function load({ fetch }) {
-		const sections = await fetch(`docs.json`).then(r => r.json());
+		const sections = await fetch(`docs.json`).then((r) => r.json());
 		return {
 			props: { sections }
 		};
@@ -8,7 +8,7 @@
 </script>
 
 <script>
-	import { Docs } from '@sveltejs/site-kit'
+	import { Docs } from '@sveltejs/site-kit';
 
 	export let sections;
 </script>
@@ -16,9 +16,9 @@
 <svelte:head>
 	<title>Docs • SvelteKit</title>
 
-	<meta name="twitter:title" content="SvelteKit docs">
-	<meta name="twitter:description" content="The next small thing in web development">
-	<meta name="Description" content="The next small thing in web development">
+	<meta name="twitter:title" content="SvelteKit docs" />
+	<meta name="twitter:description" content="The next small thing in web development" />
+	<meta name="Description" content="The next small thing in web development" />
 </svelte:head>
 
-<Docs {sections} project="sveltekit"/>
+<Docs {sections} project="kit" path="/documentation" />

--- a/sites/kit.svelte.dev/src/routes/migrating/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/migrating/index.svelte
@@ -1,6 +1,6 @@
 <script context="module">
 	export async function load({ fetch }) {
-		const sections = await fetch(`migrating.json`).then(r => r.json());
+		const sections = await fetch(`migrating.json`).then((r) => r.json());
 		return {
 			props: { sections }
 		};
@@ -8,7 +8,7 @@
 </script>
 
 <script>
-	import { Docs } from '@sveltejs/site-kit'
+	import { Docs } from '@sveltejs/site-kit';
 
 	export let sections;
 </script>
@@ -16,9 +16,9 @@
 <svelte:head>
 	<title>Migration • SvelteKit</title>
 
-	<meta name="twitter:title" content="SvelteKit migration guides">
-	<meta name="twitter:description" content="The next small thing in web development">
-	<meta name="Description" content="The next small thing in web development">
+	<meta name="twitter:title" content="SvelteKit migration guides" />
+	<meta name="twitter:description" content="The next small thing in web development" />
+	<meta name="Description" content="The next small thing in web development" />
 </svelte:head>
 
-<Docs {sections} project="sveltekit" dir="migrating"/>
+<Docs {sections} project="kit" path="/documentation" dir="migrating" />


### PR DESCRIPTION
Still not going to be a really sensible way to make editing docs easy until the docs JSON API server is set up, but we'd probably be making this change anyway.

Also some bonus reformatting from Prettier.

edit: Also fixed the migrating page.

Closes #8.