### PR TITLE
Add missing link SVG and tweak styling

### DIFF
--- a/packages/site-kit/components/Docs.svelte
+++ b/packages/site-kit/components/Docs.svelte
@@ -234,11 +234,6 @@
 		border: none !important; /* TODO get rid of linkify */
 	}
 
-	.content :global(h2 > .anchor),
-	.content :global(h3 > .anchor) {
-		top: 0.75em;
-	}
-
 	@media (min-width: 768px) {
 		.content :global(h2):hover :global(.anchor),
 		.content :global(h3):hover :global(.anchor),

--- a/sites/kit.svelte.dev/static/icons/link.svg
+++ b/sites/kit.svelte.dev/static/icons/link.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="width:24px;height:24px" viewBox="0 0 24 24">
+	<g fill="none" stroke="#333">
+		<path d="M9,7L6,7A2 2 0 0 0 6,17L9,17"/>
+		<path d="M15,7L18,7A2 2 0 0 1 18,17L15,17"/>
+		<path d="M7,12L17,12"/>
+	</g>
+</svg>


### PR DESCRIPTION
The title heading link SVG was not showing up on Kit docs, looks like file wasn't moved over to the project. Added missing image and tweaked styles to make it align correctly.