### PR TITLE
Add preloading indicator from Svelte site

### DIFF
--- a/packages/site-kit/components/PreloadingIndicator.svelte
+++ b/packages/site-kit/components/PreloadingIndicator.svelte
@@ -1,0 +1,63 @@
+<script>
+	import { onMount } from 'svelte';
+
+	let p = 0;
+	let visible = false;
+
+	onMount(() => {
+		function next() {
+			visible = true;
+			p += 0.1;
+
+			const remaining = 1 - p;
+			if (remaining > 0.15) setTimeout(next, 500 / remaining);
+		}
+
+		setTimeout(next, 250);
+	});
+</script>
+
+<style>
+	.progress-container {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 4px;
+		z-index: 999;
+	}
+
+	.progress {
+		position: absolute;
+		left: 0;
+		top: 0;
+		height: 100%;
+		background-color: var(--prime);
+		transition: width 0.4s;
+	}
+
+	.fade {
+		position: fixed;
+		width: 100%;
+		height: 100%;
+		background-color: rgba(255,255,255,0.3);
+		pointer-events: none;
+		z-index: 998;
+		animation: fade 0.4s;
+	}
+
+	@keyframes fade {
+		from { opacity: 0 }
+		to { opacity: 1 }
+	}
+</style>
+
+{#if visible}
+	<div class="progress-container">
+		<div class="progress" style="width: {p * 100}%"></div>
+	</div>
+{/if}
+
+{#if p >= 0.4}
+	<div class="fade"></div>
+{/if}

--- a/packages/site-kit/index.js
+++ b/packages/site-kit/index.js
@@ -6,3 +6,4 @@ export { default as Icons } from './components/Icons.svelte';
 export { default as Nav } from './components/Nav.svelte';
 export { default as NavItem } from './components/NavItem.svelte';
 export { default as Section } from './components/Section.svelte';
+export { default as PreloadingIndicator } from './components/PreloadingIndicator.svelte';

--- a/sites/kit.svelte.dev/src/routes/$layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/$layout.svelte
@@ -1,11 +1,37 @@
 <script>
 	import '@sveltejs/site-kit/base.css';
-	import { page } from '$app/stores';
-	import { Icons, Icon, Nav, NavItem } from '@sveltejs/site-kit';
+	import { page, navigating } from '$app/stores';
+	import { Icons, Icon, Nav, NavItem, PreloadingIndicator } from '@sveltejs/site-kit';
 
 	// TODO
 	export let segment;
 </script>
+
+<Icons />
+
+{#if $navigating}
+	<PreloadingIndicator />
+{/if}
+
+<Nav {segment} {page} logo="images/svelte-kit-horizontal.svg">
+	<NavItem segment="docs">Docs</NavItem>
+	<NavItem segment="faq">FAQ</NavItem>
+	<NavItem segment="migrating">Migrating</NavItem>
+
+	<NavItem external="https://svelte.dev">Svelte</NavItem>
+
+	<NavItem external="https://svelte.dev/chat" title="Discord Chat">
+		<Icon name="message-square" />
+	</NavItem>
+
+	<NavItem external="https://github.com/sveltejs/kit" title="GitHub Repo">
+		<Icon name="github" />
+	</NavItem>
+</Nav>
+
+<main>
+	<slot />
+</main>
 
 <style>
 	/* :global(html) {
@@ -20,25 +46,3 @@
 		overflow-x: hidden;
 	}
 </style>
-
-<Icons/>
-
-<Nav {segment} {page} logo="images/svelte-kit-horizontal.svg">
-	<NavItem segment="docs">Docs</NavItem>
-	<NavItem segment="faq">FAQ</NavItem>
-	<NavItem segment="migrating">Migrating</NavItem>
-
-	<NavItem external="https://svelte.dev">Svelte</NavItem>
-
-	<NavItem external="https://svelte.dev/chat" title="Discord Chat">
-		<Icon name="message-square"/>
-	</NavItem>
-
-	<NavItem external="https://github.com/sveltejs/kit" title="GitHub Repo">
-		<Icon name="github"/>
-	</NavItem>
-</Nav>
-
-<main>
-	<slot></slot>
-</main>


### PR DESCRIPTION
Closes #26 by adding the loading indicator from the original Svelte site to the new kit.svelte.dev site. I added the <PreloadingIndicator /> component to the site-kit package in this repo.

**Preview**
![recording](https://user-images.githubusercontent.com/10662340/115860565-05c72c00-a475-11eb-8569-b81952947d08.gif)
