### PR TITLE
Highlight active page in nav, fix touch menu opening

### DIFF
--- a/packages/site-kit/components/Nav.svelte
+++ b/packages/site-kit/components/Nav.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { setContext } from 'svelte';
 	import { writable } from 'svelte/store';
+	import Icon from './Icon.svelte';
 
 	export let segment;
 	export let page;
@@ -66,11 +67,16 @@
 		</a>
 		<ul
 			class:open
-			on:touchstart|passive|capture={intercept_touchstart}
+			on:touchstart|capture={intercept_touchstart}
 			on:mouseenter={() => (open = true)}
 			on:mouseleave={() => (open = false)}
 		>
-			<li class="hide-if-desktop" class:active={!segment}><a sveltekit:prefetch href=".">{home}</a></li>
+			<div class="open-menu-button hide-if-desktop" class:open>
+				<Icon name="chevron" size="1em" />
+			</div>
+			<li class="hide-if-desktop" class:active={$current === ''}>
+				<a sveltekit:prefetch href="/">{home}</a>
+			</li>
 			<slot name="nav-center" />
 			{#if open}
 				<li class="hide-if-desktop">
@@ -124,7 +130,7 @@
 	}
 
 	.nav-spot {
-		width: 40rem;
+		width: 50rem;
 		height: 4.2rem;
 	}
 
@@ -139,8 +145,8 @@
 
 	ul {
 		position: relative;
-		padding: 0 3rem 0 0;
 		margin: 0;
+		padding: 0 1.5rem 0 0;
 	}
 
 	ul::after {
@@ -185,6 +191,10 @@
 		display: block;
 	}
 
+	ul.open :global(.nav-right) {
+		padding-right: 2rem;
+	}
+
 	ul.open :global(.nav-right) :global(a) {
 		padding: 1.5rem;
 		display: block;
@@ -192,6 +202,16 @@
 
 	ul.open :global(li):first-child :global(a) {
 		padding-top: 1.5rem;
+	}
+
+	.open-menu-button {
+		position: absolute;
+		top: 0;
+		right: 0;
+	}
+
+	.open-menu-button.open {
+		display: none;
 	}
 
 	.home {

--- a/sites/kit.svelte.dev/src/routes/$layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/$layout.svelte
@@ -1,10 +1,10 @@
 <script>
 	import '@sveltejs/site-kit/base.css';
 	import { page, navigating } from '$app/stores';
-	import { Icons, Icon, Nav, NavItem, PreloadingIndicator } from '@sveltejs/site-kit';
+	import { Icons, Nav, NavItem, PreloadingIndicator } from '@sveltejs/site-kit';
 
-	// TODO
 	export let segment;
+	$: segment = $page.path.split('/').pop();
 </script>
 
 <Icons />
@@ -49,14 +49,14 @@
 		flex: 1;
 		flex-direction: column;
 		justify-content: center;
-		align-items: center;
+		align-items: flex-end;
 	}
 
 	.nav-right {
 		height: 100%;
 		margin: 0;
 		display: flex;
-		justify-content: center;
+		justify-content: flex-end;
 		align-items: center;
 		font-family: var(--font);
 		line-height: 1;
@@ -79,10 +79,7 @@
 	@media (min-width: 768px) {
 		.nav-center {
 			flex-direction: row;
-		}
-
-		.nav-right {
-			justify-content: flex-end;
+			align-items: center;
 		}
 
 		.nav-right img {


### PR DESCRIPTION
Closes #28 and #33. The $layout now passes the current segment to the Nav component so that the active page is highlighted. I have also:

- Added a chevron to indicate the drop down menu
- Made minor styling tweaks to accommodate the menu
- Removed the `passive` event modifier to fix #33

**Mobile**
![recording(3)](https://user-images.githubusercontent.com/10662340/115964838-abf45e00-a569-11eb-80fe-c3b70c4e5321.gif)

**Desktop**
![recording(4)](https://user-images.githubusercontent.com/10662340/115964850-b57dc600-a569-11eb-80f8-897754885f46.gif)
