### PR TITLE
a11y: make header visible when focus within

### DIFF
--- a/packages/site-kit/components/Nav.svelte
+++ b/packages/site-kit/components/Nav.svelte
@@ -105,12 +105,11 @@
 		font-family: var(--font);
 		z-index: 100;
 		user-select: none;
-		transform: translate(0, calc(-100% - 1rem));
 		transition: transform 0.2s;
 	}
 
-	header.visible {
-		transform: none;
+	header:not(.visible):not(:focus-within) {
+		transform: translate(0, calc(-100% - 1rem));
 	}
 
 	nav {


### PR DESCRIPTION
This PR makes the header visible when focus is inside it.

Before this change, if you tabbed back into the header while it was hidden, your focus would be lost. I updated the styles to show the header if the user has tabbed into it, while preserving the existing hide-on-scroll behavior.

Since some browsers [don't support](https://caniuse.com/css-focus-within) `:focus-within` (mainly old Edge), I inverted the current CSS selectors so that the header is shown by default and only hidden if the browser supports focus-within. Otherwise, browsers that don't support focus-within would throw out the whole rule, permanently hiding the header for those users.