### PR TITLE
Fix offset anchor in FAQ

### DIFF
--- a/packages/site-kit/components/Docs.svelte
+++ b/packages/site-kit/components/Docs.svelte
@@ -246,7 +246,7 @@
 	.content :global(.offset-anchor) {
 		position: relative;
 		display: block;
-		top: calc(-1 * (var(--nav-h) + var(--top-offset) - 1rem));
+		top: calc(-1 * var(--top-offset));
 		width: 0;
 		height: 0;
 	}

--- a/sites/kit.svelte.dev/src/routes/faq/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/faq/index.svelte
@@ -72,7 +72,7 @@
 	.faqs :global(.offset-anchor) {
 		position: relative;
 		display: block;
-		top: calc(-1 * (var(--nav-h) + var(--top-offset) - 1rem));
+		top: calc(-1 * var(--top-offset));
 		width: 0;
 		height: 0;
 	}

--- a/sites/kit.svelte.dev/src/routes/faq/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/faq/index.svelte
@@ -27,7 +27,7 @@
 	{#each faqs as faq}
 		<article class="faq">
 			<h2>
-				<a id={faq.slug} class="offset-anchor" />
+				<span id={faq.slug} class="offset-anchor" />
 				{faq.title}
 				<Permalink href="faq#{faq.slug}" />
 			</h2>
@@ -69,6 +69,14 @@
 		font-size: 0.8rem;
 	}
 
+	.faqs :global(.offset-anchor) {
+		position: relative;
+		display: block;
+		top: calc(-1 * (var(--nav-h) + var(--top-offset) - 1rem));
+		width: 0;
+		height: 0;
+	}
+
 	.faqs :global(.anchor) {
 		position: absolute;
 		display: block;
@@ -87,7 +95,7 @@
 	}
 
 	@media (min-width: 768px) {
-		.content :global(.anchor:focus),
+		.faqs :global(.anchor:focus),
 		.faqs :global(h2):hover :global(.anchor),
 		.faqs :global(h3):hover :global(.anchor),
 		.faqs :global(h4):hover :global(.anchor),


### PR DESCRIPTION
This PR fixes the offset anchors in the FAQ so that the heading linked to is not covered by the header. 

For example, [this link](https://kit.svelte.dev/faq#hmr) looks like this in production (the "How do I use HMR with SvelteKit?" is covered by the header)...
![image](https://user-images.githubusercontent.com/4992896/116433206-20dfc600-a7fe-11eb-858c-7191f971e9e9.png)


And like this with my changes applied...
![image](https://user-images.githubusercontent.com/4992896/116433141-11f91380-a7fe-11eb-9a14-ed95f92b8de5.png)

The implementation was copied from the Docs component.

I also fixed the permalink focus styles in the FAQ.