### PR TITLE
Add h1s and fix heading order

### DIFF
--- a/packages/site-kit/components/Docs.svelte
+++ b/packages/site-kit/components/Docs.svelte
@@ -74,6 +74,7 @@
 </script>
 
 <div bind:this={container} class="content listify">
+	<slot name="header"></slot>
 	{#each sections as section}
 		<section data-id={section.slug}>
 			<h2>

--- a/packages/site-kit/components/Hero.svelte
+++ b/packages/site-kit/components/Hero.svelte
@@ -12,7 +12,7 @@
 	<div class="hero-container">
 		<div class="hero-text">
 			<img alt="{title} logotype" width="400" height="50" class="logotype" src={logotype} />
-			<h3>{tagline}</h3>
+			<div class="tagline">{tagline}</div>
 		</div>
 
 		<div class="hero-image">
@@ -55,7 +55,7 @@ linear-gradient(0deg, #DBE7EF, #DBE7EF);
 		mix-blend-mode: multiply;
 	}
 
-	.hero-banner h3 {
+	.hero-banner .tagline {
 		margin-top: 0;
 		position: relative;
 		font-size: 2rem;
@@ -66,6 +66,7 @@ linear-gradient(0deg, #DBE7EF, #DBE7EF);
 		text-transform: uppercase;
 		color: var(--text);
 		max-width: 12em;
+		font-family: var(--font);
 	}
 
 	.logotype {
@@ -90,7 +91,7 @@ linear-gradient(0deg, #DBE7EF, #DBE7EF);
 	}
 
 	@media (min-width: 480px) {
-		.hero-banner h3 {
+		.hero-banner .tagline {
 			max-width: auto;
 		}
 
@@ -121,7 +122,7 @@ linear-gradient(0deg, #DBE7EF, #DBE7EF);
 			transform: scale(1.8);
 		}
 
-		.hero-banner h3 {
+		.hero-banner .tagline {
 			text-align: right;
 			max-width: 12em;
 		}

--- a/packages/site-kit/components/Hero.svelte
+++ b/packages/site-kit/components/Hero.svelte
@@ -11,7 +11,7 @@
 <section class="hero-banner">
 	<div class="hero-container">
 		<div class="hero-text">
-			<img alt="{title} logotype" width="400" height="50" class="logotype" src={logotype} />
+			<img alt="{title}" width="400" height="50" class="logotype" src={logotype} />
 			<div class="tagline">{tagline}</div>
 		</div>
 

--- a/sites/kit.svelte.dev/src/routes/docs/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/docs/index.svelte
@@ -22,5 +22,6 @@
 	<meta name="Description" content="Complete documentation for SvelteKit">
 </svelte:head>
 
-<h1 class="visually-hidden">Docs</h1>
-<Docs {sections} project="kit" path="/documentation" />
+<Docs {sections} project="kit" path="/documentation">
+	<h1 slot="header">Documentation</h1>
+</Docs>

--- a/sites/kit.svelte.dev/src/routes/docs/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/docs/index.svelte
@@ -22,4 +22,5 @@
 	<meta name="Description" content="Complete documentation for SvelteKit">
 </svelte:head>
 
+<h1 class="visually-hidden">Docs</h1>
 <Docs {sections} project="kit" path="/documentation" />

--- a/sites/kit.svelte.dev/src/routes/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/index.svelte
@@ -18,6 +18,7 @@
 	<meta name="description" content="SvelteKit is the official Svelte application framework">
 </svelte:head>
 
+<h1 class="visually-hidden">SvelteKit</h1>
 <Hero
 	title="SvelteKit"
 	logotype="images/svelte-kit-logotype.svg"

--- a/sites/kit.svelte.dev/src/routes/migrating/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/migrating/index.svelte
@@ -22,5 +22,6 @@
 	<meta name="description" content="How to migrate your app from Sapper to SvelteKit">
 </svelte:head>
 
-<h1 class="visually-hidden">Migration</h1>
-<Docs {sections} project="kit" path="/documentation" dir="migrating" />
+<Docs {sections} project="kit" path="/documentation" dir="migrating">
+	<h1 slot="header">Migration</h1>
+</Docs>

--- a/sites/kit.svelte.dev/src/routes/migrating/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/migrating/index.svelte
@@ -22,4 +22,5 @@
 	<meta name="description" content="How to migrate your app from Sapper to SvelteKit">
 </svelte:head>
 
+<h1 class="visually-hidden">Migration</h1>
 <Docs {sections} project="kit" path="/documentation" dir="migrating" />


### PR DESCRIPTION
Several pages on the SvelteKit site did not have an h1, resulting in an [axe a11y violation](https://dequeuniversity.com/rules/axe/4.1/page-has-heading-one). This PR adds those headings and makes them only visible to screen readers so the pages look the same.

Also, the use of an h3 in the Hero component resulted in an [invalid heading order](https://dequeuniversity.com/rules/axe/4.1/heading-order) violation. There didn't seem to be much benefit to this being a heading, so I changed it to a div and updated the styles so it looked the same.