### PR TITLE
Fix hero image not rendering in Safari on older macOS versions

### DIFF
--- a/packages/site-kit/components/Hero.svelte
+++ b/packages/site-kit/components/Hero.svelte
@@ -17,7 +17,7 @@
 
 		<div class="hero-image">
 		<picture>
-			<source srcset="{background}.webp">
+			<source srcset="{background}.webp" type="image/webp">
 			<img {alt} {width} {height} src="{background}.png">
 		</picture>
 	</div>


### PR DESCRIPTION
Safari on Catalina and older (which does not support WebP) was attempting to display the .webp version of the hero image, rather than the fallback .png version. Making the `type` explicit solves the issue.

I believe this may be an implementation bug in Safari, as [MDN states](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#attr-type):

> If the type attribute isn't specified, the media's type is retrieved from the server and checked to see if the user agent can handle it; if it can't be rendered, the next <source> is checked.
