### PR TITLE
Fix `picture` tag fallback for Safari

### DIFF
--- a/packages/site-kit/components/Hero.svelte
+++ b/packages/site-kit/components/Hero.svelte
@@ -16,11 +16,12 @@
 		</div>
 
 		<div class="hero-image">
-		<picture>
-			<source srcset="{background}.webp">
-			<img {alt} {width} {height} src="{background}.png">
-		</picture>
-	</div>
+			<picture>
+				<source type="image/webp" srcset="{background}.webp" />
+				<source type="image/png" srcset="{background}.png" />
+				<img {alt} {width} {height} src="{background}.png" />
+			</picture>
+		</div>
 	</div>
 </section>
 


### PR DESCRIPTION
Certain versions of Safari do not support `img` as a fallback for `picture`, so we need the png to be a `source` fallback as well.
![image](https://user-images.githubusercontent.com/1460917/116802326-20b43300-ab3c-11eb-990e-4bb2874acfa9.png)

In addition, MIME types are added to skip having to check it with the server.