### PR TITLE
Fixed relative path in assets reference

### DIFF
--- a/sites/kit.svelte.dev/src/routes/__layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/__layout.svelte
@@ -13,7 +13,7 @@
 	<PreloadingIndicator />
 {/if}
 
-<Nav {segment} {page} logo="images/svelte-kit-horizontal.svg">
+<Nav {segment} {page} logo="/images/svelte-kit-horizontal.svg">
 	<div slot="nav-center" class="nav-center">
 		<NavItem segment="docs">Docs</NavItem>
 		<NavItem segment="faq">FAQ</NavItem>
@@ -22,11 +22,11 @@
 
 	<div class="nav-right" slot="nav-right">
 		<NavItem external="https://svelte.dev/chat" title="Discord Chat">
-			<img class="nav-icon" width="20px" src="./icons/discord.svg" alt="Open Discord chat" />
+			<img class="nav-icon" width="20px" src="/icons/discord.svg" alt="Open Discord chat" />
 		</NavItem>
 
 		<NavItem external="https://github.com/sveltejs/kit" title="GitHub Repo">
-			<img class="nav-icon" width="20px" src="./icons/github.svg" alt="Open Svelte GitHub page" />
+			<img class="nav-icon" width="20px" src="/icons/github.svg" alt="Open Svelte GitHub page" />
 		</NavItem>
 	</div>
 </Nav>


### PR DESCRIPTION
When navigating to any page deeper than 1 level.
![image](https://user-images.githubusercontent.com/7234614/137594191-e8e9bc09-0105-454d-af1d-c57ed1d620fb.png)

How it should behave:
![image](https://user-images.githubusercontent.com/7234614/137594216-097d25c7-e2ed-442c-a223-86d42dc085f7.png)

