### PR TITLE
Update URLs

### DIFF
--- a/sites/kit.svelte.dev/src/routes/__layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/__layout.svelte
@@ -15,9 +15,9 @@
 
 <Nav {segment} {page} logo="images/svelte-kit-horizontal.svg">
 	<div slot="nav-center" class="nav-center">
-		<NavItem segment="docs">Docs</NavItem>
-		<NavItem segment="faq">FAQ</NavItem>
-		<NavItem segment="migrating">Migrating</NavItem>
+		<NavItem segment="/docs">Docs</NavItem>
+		<NavItem segment="/faq">FAQ</NavItem>
+		<NavItem segment="/migrating">Migrating</NavItem>
 	</div>
 
 	<div class="nav-right" slot="nav-right">


### PR DESCRIPTION
If user trying to navigate from kit.svelte.dev/*/* by clicking on the `NavItem` it will be redirected to kit.svelte.dev/*/NavItem instead of kit.svelte.dev/NavItem.