### PR TITLE
Set rel="external" on external NavItem

### DIFF
--- a/packages/site-kit/components/NavItem.svelte
+++ b/packages/site-kit/components/NavItem.svelte
@@ -9,7 +9,7 @@
 </script>
 
 {#if external}
-	<li><a href={external} {title}><slot></slot></a></li>
+	<li><a href={external} {title} rel="external"><slot></slot></a></li>
 {:else}
 	<li class:active="{$current === segment}"><a sveltekit:prefetch href={segment} {title}><slot></slot></a></li>
 {/if}


### PR DESCRIPTION
This allows linking to endpoints and thereby solves the broken link to https://svelte.dev/chat from the header on svelte.dev.

(made a pr [here](https://github.com/sveltejs/site-kit/pull/47) but only later noticed that that package is abandoned in favour of this one)