### PR TITLE
Add note about node version requirement

### DIFF
--- a/sites/kit.svelte.dev/src/routes/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/index.svelte
@@ -80,6 +80,7 @@
 
 	<div slot="how">
 		<pre><code>
+<span class="comment"># You'll need Node.js v14 or higher</span>
 npm init <span class="orange-highlight">svelte@next</span> my-app
 cd my-app
 npm install
@@ -99,5 +100,10 @@ npm run dev -- --open
 
 	.orange-highlight {
 		color: var(--prime);
+	}
+
+	.comment {
+		color: var(--second);
+		font-style: italic;
 	}
 </style>


### PR DESCRIPTION
The `Unexpected token '.'` error has appeared quite a few times on discord and recently on the Kit issue tracker as well. Older node.js doesn't support optional chaining so starting the dev server fails with no changes to the starter template whatsoever. It isn't a great experience for new people if they have to go hunting for the fix.

I posted a screenshot on discord, that one had an extra line in it, but that should be fixed now, and it actually looks decent without the huge gap.