### PR TITLE
update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .DS_Store
 .netlify
-/node_modules
+.pnpm-debug.log
+.env
+node_modules/
+.svelte-kit/
+build/
+functions/

--- a/sites/kit.svelte.dev/.gitignore
+++ b/sites/kit.svelte.dev/.gitignore
@@ -1,6 +1,0 @@
-.DS_Store
-node_modules
-.env
-/.svelte-kit
-/build
-/functions


### PR DESCRIPTION
I was looking at adding svelte.dev. This is stuff we'll need for that

Move common stuff into base project. `svelte.dev` stuff will be in sub-project: https://github.com/sveltejs/svelte/pull/6983

Or do we prefer everything being the `.gitignore` for the sub-projects?