### PR TITLE
use svelte.dev/chat in kit instead of /chat

### DIFF
--- a/sites/kit.svelte.dev/src/routes/__layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/__layout.svelte
@@ -35,7 +35,7 @@
 
 		<NavItem external="https://svelte.dev">Svelte</NavItem>
 
-		<NavItem external="chat" title="Discord Chat">
+		<NavItem external="https://svelte.dev/chat" title="Discord Chat">
 			<span class="small">Discord</span>
 			<span class="large"><Icon name="message-square" /></span>
 		</NavItem>


### PR DESCRIPTION
`https://kit.svelte.dev/chat` results in 404
We either use `https://svelte.dev/chat` or `/chat` and have 2 links to remember to change.