### PR TITLE
one debouncing approach

### DIFF
--- a/packages/repl/src/lib/Input/ModuleEditor.svelte
+++ b/packages/repl/src/lib/Input/ModuleEditor.svelte
@@ -16,6 +16,20 @@
 	export function focus() {
 		editor.focus();
 	}
+
+	let timeout;
+
+	function on_change(event) {
+		if ($bundle && $bundle.error) {
+			clearTimeout(timeout);
+			handle_change(event);
+		} else {
+			clearTimeout(timeout);
+			timeout = setTimeout(() => {
+				handle_change(event);
+			}, 150);
+		}
+	}
 </script>
 
 <style>
@@ -51,7 +65,7 @@
 			bind:this={editor}
 			{errorLoc}
 			{theme}
-			on:change={handle_change}
+			on:change={on_change}
 		/>
 	</div>
 


### PR DESCRIPTION
https://github.com/sveltejs/svelte-repl/pull/157

I actually think we can improve the experience by applying the debouncing to the error overlay and the importer specifically, rather than the whole thing. It's nice to get immediate feedback when typing