### PR TITLE
debouncing

### DIFF
--- a/packages/repl/src/lib/Input/ModuleEditor.svelte
+++ b/packages/repl/src/lib/Input/ModuleEditor.svelte
@@ -16,6 +16,23 @@
 	export function focus() {
 		editor.focus();
 	}
+
+	let error = null;
+	let warnings = [];
+	let timeout = null;
+
+	$: if ($bundle) {
+		clearTimeout(timeout);
+
+		// if there's already an error/warnings displayed, update them
+		if (error) error = $bundle.error;
+		if (warnings.length > 0) warnings = $bundle.warnings;
+
+		timeout = setTimeout(() => {
+			error = $bundle.error;
+			warnings = $bundle.warnings;
+		}, 400);
+	}
 </script>
 
 <style>
@@ -56,14 +73,12 @@
 	</div>
 
 	<div class="info">
-		{#if $bundle}
-			{#if $bundle.error}
-				<Message kind="error" details={$bundle.error} filename="{$selected.name}.{$selected.type}"/>
-			{:else if $bundle.warnings.length > 0}
-				{#each $bundle.warnings as warning}
-					<Message kind="warning" details={warning} filename="{$selected.name}.{$selected.type}"/>
-				{/each}
-			{/if}
+		{#if error}
+			<Message kind="error" details={error} filename="{$selected.name}.{$selected.type}"/>
+		{:else if warnings.length > 0}
+			{#each warnings as warning}
+				<Message kind="warning" details={warning} filename="{$selected.name}.{$selected.type}"/>
+			{/each}
 		{/if}
 	</div>
 </div>

--- a/packages/repl/src/lib/Message.svelte
+++ b/packages/repl/src/lib/Message.svelte
@@ -25,8 +25,7 @@
 </script>
 
 <div
-	in:slide={{ delay: 150, duration: 100 }}
-	out:slide={{ duration: 100 }}
+	transition:slide={{ duration: 100 }}
 	class="message {kind}"
 	class:truncate
 >

--- a/packages/repl/src/lib/Output/Viewer.svelte
+++ b/packages/repl/src/lib/Output/Viewer.svelte
@@ -1,7 +1,6 @@
 <script>
 	import { onMount, getContext } from 'svelte';
 	import getLocationFromStack from './getLocationFromStack.js';
-	import SplitPane from '../SplitPane.svelte';
 	import PaneWithPanel from './PaneWithPanel.svelte';
 	import ReplProxy from './ReplProxy.js';
 	import Console from './Console.svelte';

--- a/packages/repl/src/lib/index.svelte
+++ b/packages/repl/src/lib/index.svelte
@@ -212,19 +212,21 @@
 			packagesUrl,
 			svelteUrl,
 			onstatus: (message) => {
-				// show bundler status, but only after time has elapsed, to
-				// prevent the banner flickering
-				if (!status_visible && !status_timeout) {
-					status_timeout = setTimeout(() => {
-						status_visible = true;
-					}, 200);
-				}
-
-				status = message;
-				if (!status) {
+				if (message) {
+					// show bundler status, but only after time has elapsed, to
+					// prevent the banner flickering
+					if (!status_visible && !status_timeout) {
+						status_timeout = setTimeout(() => {
+							status_visible = true;
+						}, 400);
+					}
+				} else {
+					clearTimeout(status_timeout);
 					status_visible = false;
 					status_timeout = null;
 				}
+
+				status = message;
 			}
 		});
 

--- a/packages/repl/src/lib/index.svelte
+++ b/packages/repl/src/lib/index.svelte
@@ -201,7 +201,10 @@
 	}
 
 	let sourceErrorLoc;
+
 	let status = null;
+	let status_visible = false;
+	let status_timeout = null;
 
 	const bundler =
 		is_browser &&
@@ -209,7 +212,19 @@
 			packagesUrl,
 			svelteUrl,
 			onstatus: (message) => {
+				// show bundler status, but only after time has elapsed, to
+				// prevent the banner flickering
+				if (!status_visible && !status_timeout) {
+					status_timeout = setTimeout(() => {
+						status_visible = true;
+					}, 100);
+				}
+
 				status = message;
+				if (!status) {
+					status_visible = false;
+					status_timeout = null;
+				}
 			}
 		});
 
@@ -232,7 +247,7 @@
 		</section>
 
 		<section slot="b" style="height: 100%;">
-			<Output {svelteUrl} {status} {embedded} {relaxed} {injectedJS} {injectedCSS} {theme} />
+			<Output {svelteUrl} status={status_visible && status} {embedded} {relaxed} {injectedJS} {injectedCSS} {theme} />
 		</section>
 	</SplitPane>
 </div>

--- a/packages/repl/src/lib/index.svelte
+++ b/packages/repl/src/lib/index.svelte
@@ -217,7 +217,7 @@
 				if (!status_visible && !status_timeout) {
 					status_timeout = setTimeout(() => {
 						status_visible = true;
-					}, 100);
+					}, 200);
 				}
 
 				status = message;

--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -64,7 +64,7 @@ async function fetch_if_uncached(url, uid) {
 		return fetch_cache.get(url);
 	}
 
-	await sleep(250);
+	await sleep(200);
 	if (uid !== current_id) throw ABORT;
 
 	const promise = fetch(url)


### PR DESCRIPTION
WIP. This debounces messages (so you're not constantly distracted by syntax errors while you're mid-word), and the plan is to also debounce imports (so if you type `import x from 'some-package-name'` you don't end up fetching `so` and `some-` and `some-pac` etc from unpkg.

The goal is the same as #130, but bundling still happens immediately, which is nicer UX.