### PR TITLE
move cursor to error/warning location

### DIFF
--- a/packages/repl/src/lib/CodeMirror.svelte
+++ b/packages/repl/src/lib/CodeMirror.svelte
@@ -60,6 +60,10 @@
 		if (editor) editor.clearHistory();
 	}
 
+	export function setCursor(pos) {
+		if (editor) editor.setCursor(pos);
+	}
+
 	const modes = {
 		js: {
 			name: 'javascript',

--- a/packages/repl/src/lib/index.svelte
+++ b/packages/repl/src/lib/index.svelte
@@ -127,7 +127,13 @@
 			const component = $components.find((c) => c.name === name && c.type === type);
 			handle_select(component);
 
-			// TODO select the line/column in question
+			setTimeout(() => {
+				module_editor.focus();
+				module_editor.setCursor({
+					line: item.start.line - 1,
+					ch: item.start.column,
+				});
+			}, 0);
 		},
 
 		handle_change: (event) => {


### PR DESCRIPTION
https://github.com/sveltejs/svelte-repl/pull/137, albeit with just the `setCursor` method (I felt it better not to add more API surface area; moving the cursor, rather than selecting a range, is probably more familiar behaviour)