### PR TITLE
Fix 'edit docs' button linking to sveltejs/kit

### DIFF
--- a/sites/svelte.dev/src/routes/docs/index.svelte
+++ b/sites/svelte.dev/src/routes/docs/index.svelte
@@ -45,7 +45,7 @@
 	{#each sections as section}
 		<Section
 			{section}
-			edit="https://github.com/sveltejs/kit/edit/master/site/content/docs/{section.file}"
+			edit="https://github.com/sveltejs/svelte/edit/master/site/content/docs/{section.file}"
 			base="/docs"
 		/>
 	{/each}


### PR DESCRIPTION
replaced "https://github.com/sveltejs/kit/edit/master/site/content/docs/{section.file}" with "https://github.com/sveltejs/svelte/edit/master/site/content/docs/{section.file}"