### PR TITLE
Give heading permalinks an accessible name

### DIFF
--- a/packages/site-kit/components/docs/Main.svelte
+++ b/packages/site-kit/components/docs/Main.svelte
@@ -16,6 +16,10 @@
 				const a = document.createElement('a');
 				a.className = 'anchor';
 				a.href = `${$page.path}#${heading.id}`;
+				const span = document.createElement('span');
+				span.className = "visually-hidden";
+				span.innerHTML = "permalink";
+				a.appendChild(span);
 				heading.appendChild(a);
 			}
 		}


### PR DESCRIPTION
The permalinks on h3s and below did not have an accessible name since they didn't have any text content. This PR adds visually-hidden "permalink" text to each one, which aligns them with the site-kit Permalink component.

This resolves the 104 ["Links must have discernible text"](https://dequeuniversity.com/rules/axe/4.3/link-name) issues found via Axe DevTools.