### PR TITLE
Improve color contrast of syntax highlighting

### DIFF
--- a/packages/site-kit/code.css
+++ b/packages/site-kit/code.css
@@ -3,11 +3,12 @@
 :root {
 	--code-bg: var(--back-light);
 	--code-base: hsl(45, 7%, 35%);
-	--code-comment: hsl(210, 25%, 50%);
+	--code-comment: hsl(0, 0%, 41%);
 	--code-keyword: hsl(204, 88%, 35%);
-	--code-function: hsl(19, 87%, 45%);
-	--code-string: hsl(41, 37%, 45%);
-	--code-number: hsl(102, 27%, 50%);
+	--code-function: hsl(19, 67%, 44%);
+	--code-string: hsl(41, 37%, 38%);
+	--code-number: hsl(120, 100%, 25%);
+	--code-template-string: hsl(2, 80%, 47%);
 	--code-tags: var(--code-function);
 	--code-important: var(--code-string);
 }
@@ -68,5 +69,5 @@ pre {
 
 .token.template-string .interpolation-punctuation,
 .token.template-string .string {
-	color: #f50;
+	color: var(--code-template-string);
 }


### PR DESCRIPTION
The color contrast of the syntax highlighting in the code samples did not meet WCAG AA standards (4.5 for small text), which could make it hard to read for people with low vision. This PR updates the colors used to match that threshold. This reduces the count of [color contrast Axe violations](https://dequeuniversity.com/rules/axe/4.0/color-contrast) to 233 from 1493 instances.

Contrast changes (checked using https://contrast-ratio.com with #f6fafd background):
- code-comment: was 3.93, now 5.23
- code-function: was 4.01, now 4.5
- code-string: was 3.49, now 4.65
- code-number: was 2.84, now 4.89
- code-template-string: was 3.05, now 4.85

Before:
![image](https://user-images.githubusercontent.com/4992896/146418888-6afad3fd-b78a-4ee9-9dae-8edbdd8b66e5.png)

After: 
![image](https://user-images.githubusercontent.com/4992896/146418798-60dda2e5-a86d-4a1a-9fd5-3fa25534f065.png)

I made a similar PR against the old site repo (https://github.com/sveltejs/svelte/pull/5681), but it looks like those changes got lost at some point in the migration. This PR uses those changes as a base but leaves all colors as HSL and does not change tokens that now meet the 4.5 threshold.