### PR TITLE
Add ability to delete single gists

### DIFF
--- a/db/setup.sql
+++ b/db/setup.sql
@@ -82,7 +82,7 @@ as $$
 		return query
 		select gist.id, gist.name, gist.created_at, gist.updated_at
 		from gist
-		where gist.userid = list_userid
+		where gist.userid = list_userid and gist.deleted_at is null
 		order by coalesce(gist.updated_at, gist.created_at) desc
 		limit list_count + 1
 		offset list_start;
@@ -129,7 +129,7 @@ as $$
 	begin
 		update gist
 			set name = gist_name, files = gist_files, updated_at = now()
-			where id = gist_id and userid = gist_userid
+			where id = gist_id and userid = gist_userid and deleted_at is null
 			returning id, name, files, userid into ret;
 
 		return ret;

--- a/db/setup.sql
+++ b/db/setup.sql
@@ -36,8 +36,9 @@ create table public.gist (
 	created_at timestamptz default now(),
 	name text,
 	files json,
+	userid int8,
 	updated_at timestamptz,
-	userid int8
+	deleted_at timestamptz
 );
 
 -- foreign key relations
@@ -86,7 +87,7 @@ returns void
 language plpgsql volatile
 as $$
 	begin
-		delete from gist where id = gist_id and userid = gist_userid;
+		update gist set deleted_at = now() where id = gist_id and userid = gist_userid;
 	end;
 $$;
 

--- a/sites/svelte.dev/src/lib/db/gist.js
+++ b/sites/svelte.dev/src/lib/db/gist.js
@@ -83,14 +83,15 @@ export async function update(user, gistid, gist) {
 }
 
 /**
- * @param {User} user
- * @param {Gist} gist
+ * @param {number} userid
+ * @param {string} id
  * @returns {void}
  */
-export async function destroy(user, gist) {
+export async function destroy(userid, id) {
 	const { error } = await client.rpc('gist_destroy', {
-		gist_id: gist.id,
-		gist_userid: user.id
+		// TODO we will probably want the ability to delete in bulk
+		gist_id: id,
+		gist_userid: userid
 	});
 
 	if (error) {

--- a/sites/svelte.dev/src/lib/db/gist.js
+++ b/sites/svelte.dev/src/lib/db/gist.js
@@ -21,7 +21,9 @@ export async function list(user, offset) {
 
 	return {
 		gists: data.slice(0, PAGE_SIZE),
-		next: data.length > PAGE_SIZE ? offset + PAGE_SIZE : null
+		next: data.length > PAGE_SIZE ? offset + PAGE_SIZE : null,
+		current: offset || null,
+		prev: offset ? Math.max(offset - PAGE_SIZE, 0) : null
 	};
 }
 

--- a/sites/svelte.dev/src/lib/db/gist.js
+++ b/sites/svelte.dev/src/lib/db/gist.js
@@ -54,7 +54,8 @@ export async function read(id) {
 	const { data, error } = await client
 		.from('gist')
 		.select('id,name,files,userid')
-		.eq('id', id);
+		.eq('id', id)
+		.is('deleted_at', null);
 
 	if (error) throw new Error(error.message);
 	return data[0];

--- a/sites/svelte.dev/src/routes/apps/_utils/page-list.js
+++ b/sites/svelte.dev/src/routes/apps/_utils/page-list.js
@@ -1,0 +1,23 @@
+export function fetch_page_list(fetch, offset) {
+	let url = 'apps.json';
+	if (offset) {
+		url += `?offset=${encodeURIComponent(offset)}`;
+	}
+	return fetch(url, {
+		credentials: 'include'
+	});
+}
+
+export async function page_list(fetch, offset) {
+	let out = {
+		gists: [],
+		next: null,
+		current: null,
+		prev: null
+	};
+	const r = await fetch_page_list(fetch, offset);
+	if (!r.ok) {
+		return out;
+	}
+	return r.json();
+}

--- a/sites/svelte.dev/src/routes/apps/index.json.js
+++ b/sites/svelte.dev/src/routes/apps/index.json.js
@@ -11,3 +11,23 @@ export async function get({ query, locals }) {
 		return { status: 401 };
 	}
 }
+
+export async function del({ locals, body }) {
+	const { user } = locals;
+	if (!user) return;
+
+	try {
+		await gist.destroy(user, body);
+
+		return {
+			status: 202
+		};
+	} catch (err) {
+		return {
+			status: 500,
+			body: {
+				error: err.message
+			}
+		};
+	}
+}

--- a/sites/svelte.dev/src/routes/apps/index.json.js
+++ b/sites/svelte.dev/src/routes/apps/index.json.js
@@ -11,23 +11,3 @@ export async function get({ query, locals }) {
 		return { status: 401 };
 	}
 }
-
-export async function del({ locals, body }) {
-	const { user } = locals;
-	if (!user) return;
-
-	try {
-		await gist.destroy(user, body);
-
-		return {
-			status: 202
-		};
-	} catch (err) {
-		return {
-			status: 500,
-			body: {
-				error: err.message
-			}
-		};
-	}
-}

--- a/sites/svelte.dev/src/routes/apps/index.svelte
+++ b/sites/svelte.dev/src/routes/apps/index.svelte
@@ -31,6 +31,28 @@
 	const { login, logout } = getContext('app');
 
 	const format = (str) => ago(new Date(str));
+
+	async function delete_gist(gist) {
+		if (!confirm(`Do you wish to permanently delete the gist "${gist.name}"`)) {
+			return;
+		}
+		try {
+			const r = await fetch('apps.json', {
+				method: 'DELETE',
+				credentials: 'include',
+				body: JSON.stringify(gist),
+				headers: { 'content-type': 'application/json' }
+			});
+			if (r.status !== 202) {
+				throw new Error(
+					`Unexpected response when trying to delete gist. ${r.status}: ${r.statusText}`
+				);
+			}
+			window.location.reload();
+		} catch (e) {
+			console.log('Error', e);
+		}
+	}
 </script>
 
 <svelte:head>
@@ -62,6 +84,7 @@
 						<h2>{gist.name}</h2>
 						<span>updated {format(gist.updated_at || gist.created_at)}</span>
 					</a>
+					<button on:click={() => delete_gist(gist)} class="delete-gist-btn">&times;</button>
 				</li>
 			{/each}
 		</ul>
@@ -116,6 +139,7 @@
 
 	li {
 		margin: 0 0 1em 0;
+		display: flex;
 	}
 
 	h2 {
@@ -135,5 +159,20 @@
 	li span {
 		font-size: 14px;
 		color: #999;
+	}
+
+	.delete-gist-btn {
+		font-size: medium;
+		color: #999;
+		border-radius: 100%;
+		width: 2rem;
+		height: 2rem;
+		margin: 4px 0 0 8px;
+		display: none;
+		border: 0;
+		background: none;
+	}
+	li:hover .delete-gist-btn {
+		display: block;
 	}
 </style>

--- a/sites/svelte.dev/src/routes/apps/index.svelte
+++ b/sites/svelte.dev/src/routes/apps/index.svelte
@@ -37,11 +37,9 @@
 			return;
 		}
 		try {
-			const r = await fetch('apps.json', {
+			const r = await fetch(`/repl/${gist.id}.json`, {
 				method: 'DELETE',
-				credentials: 'include',
-				body: JSON.stringify(gist),
-				headers: { 'content-type': 'application/json' }
+				credentials: 'include'
 			});
 			if (r.status !== 202) {
 				throw new Error(

--- a/sites/svelte.dev/src/routes/repl/[id]/index.json.js
+++ b/sites/svelte.dev/src/routes/repl/[id]/index.json.js
@@ -92,3 +92,23 @@ export async function put({ locals, params, body }) {
 		status: 204
 	};
 }
+
+export async function del({ locals, params }) {
+	const { user } = locals;
+	if (!user) return;
+
+	try {
+		await gist.destroy(user.id, params.id);
+
+		return {
+			status: 202
+		};
+	} catch (err) {
+		return {
+			status: 500,
+			body: {
+				error: err.message
+			}
+		};
+	}
+}


### PR DESCRIPTION
For a some time I've wanted to be able to cleanup my gists in the apps list.
This PR adds this ability, by adding a delete button to each gist in the "Your apps" list.

I made the change as small and simple as possible, using the browsers built in `confirm` dialog.

**UPDATE 2021-12-19**:

I've pushed some changes to make this a more robust and proper solution:  
When a gist is deleted, the new gists list for the current page is re-fetched and loaded. If there are no gists for the current offset after a deletion, and we have a prev offset (i.e. last gist on last page deleted), we'll navigate to the prev page.

I also added a "Previous" pagination link to the bottom of the list.

A page state "deleteState" is introduced to make sure we don't open up for deletion during deletion on slower connections.

**/UPDATE**

### Some screenshots

On hover:  
<img width="510" alt="Screen Shot 2021-12-17 at 16 27 56" src="https://user-images.githubusercontent.com/570998/146569144-ef1fd6f1-f550-4b34-a860-da731a3b4cca.png">

Confirm:  
<img width="456" alt="Screen Shot 2021-12-19 at 16 43 02" src="https://user-images.githubusercontent.com/570998/146681202-552f2b9a-e7ba-4ece-9dbe-f13168a30760.png">

Pagination:  
<img width="517" alt="Screen Shot 2021-12-19 at 16 42 40" src="https://user-images.githubusercontent.com/570998/146681208-f4fefb64-f11b-4ddd-81cf-209685431203.png">

