### PR TITLE
fix tutorial nav arrows position

### DIFF
--- a/sites/svelte.dev/src/routes/tutorial/[slug]/_TableOfContents.svelte
+++ b/sites/svelte.dev/src/routes/tutorial/[slug]/_TableOfContents.svelte
@@ -58,6 +58,7 @@
 <style>
 	nav {
 		display: grid;
+		align-items: center;
 		grid-template-columns: 2.5em 1fr 2.5em;
 		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 	}

--- a/sites/svelte.dev/src/routes/tutorial/[slug]/_TableOfContents.svelte
+++ b/sites/svelte.dev/src/routes/tutorial/[slug]/_TableOfContents.svelte
@@ -93,7 +93,7 @@
 	span {
 		white-space: nowrap;
 		position: relative;
-		top: 0.3em;
+		top: 0.1em;
 	}
 
 	strong {


### PR DESCRIPTION
The tutorial arrows look fine when served locally but appears different in production.

![image](https://user-images.githubusercontent.com/8033084/146588018-a7182e69-3153-4c7d-8a9a-f24f2cdad2d6.png)

This line should align them to the center.

![image](https://user-images.githubusercontent.com/8033084/146588116-16c12cbd-a710-4b57-90af-595e123a37af.png)
