### PR TITLE
Fix #212 Edit this page link in Tutorials not linked to the correct page.

### DIFF
--- a/sites/svelte.dev/src/routes/tutorial/[slug]/index.svelte
+++ b/sites/svelte.dev/src/routes/tutorial/[slug]/index.svelte
@@ -74,7 +74,7 @@
 		'https://github.com/sveltejs/svelte/tree/master/site/content/tutorial';
 
 	$: selected = lookup.get(slug);
-	$: improve_link = ``;
+	$: improve_link = '';
 
 	//`${tutorial_repo_link}/${selected.chapter.section_dir}/${selected.chapter.chapter_dir}`;
 

--- a/sites/svelte.dev/src/routes/tutorial/[slug]/index.svelte
+++ b/sites/svelte.dev/src/routes/tutorial/[slug]/index.svelte
@@ -71,10 +71,10 @@
 	// TODO: this will need to be changed to the master branch, and probably should be dynamic instead of included
 	//   here statically
 	const tutorial_repo_link =
-		'https://github.com/sveltejs/svelte/tree/master/documentation/tutorial';
+		'https://github.com/sveltejs/svelte/tree/master/site/content/tutorial';
 
 	$: selected = lookup.get(slug);
-	$: improve_link = '';
+	$: improve_link = ``;
 
 	//`${tutorial_repo_link}/${selected.chapter.section_dir}/${selected.chapter.chapter_dir}`;
 
@@ -155,7 +155,7 @@
 				</div>
 
 				<div class="improve-chapter">
-					<a class="no-underline" href={improve_link}>Edit this chapter</a>
+					<a class="no-underline" href={improve_link || tutorial_repo_link}>Edit this chapter</a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Right now `slug` doesn't give us the exact file name information with which we can create a link to the exact chapter in a section.

But until then users can be redirected to the tutorials index page - ttps://github.com/sveltejs/svelte/tree/master/site/content/tutorial