### PR TITLE
use ecmaVersion: 13

### DIFF
--- a/packages/repl/src/lib/workers/bundler/plugins/commonjs.js
+++ b/packages/repl/src/lib/workers/bundler/plugins/commonjs.js
@@ -14,7 +14,8 @@ export default {
 
 		try {
 			const ast = acorn.parse(code, {
-				ecmaVersion: 'latest'
+				// for some reason this hangs for some code if you use 'latest'. change with caution
+				ecmaVersion: 13
 			});
 
 			const requires = [];


### PR DESCRIPTION
it seems acorn hangs if you specify `ecmaVersion: 'latest'`. i have no idea why. anyway, this seems to fix issues like #206 and #205