### PR TITLE
ensure links are absolute

### DIFF
--- a/sites/svelte.dev/src/routes/__error.svelte
+++ b/sites/svelte.dev/src/routes/__error.svelte
@@ -68,7 +68,7 @@
 				<p>Please try reloading the page.</p>
 			{/if}
 
-			<p>If the error persists, please drop by the <a rel="external" href="chat">Discord chatroom</a> and let us know, or raise an issue on <a href="https://github.com/sveltejs/svelte">GitHub</a>. Thanks!</p>
+			<p>If the error persists, please drop by the <a rel="external" href="/chat">Discord chatroom</a> and let us know, or raise an issue on <a href="https://github.com/sveltejs/svelte">GitHub</a>. Thanks!</p>
 		{/if}
 	{:else}
 		<h1>It looks like you're offline</h1>

--- a/sites/svelte.dev/src/routes/apps/index.svelte
+++ b/sites/svelte.dev/src/routes/apps/index.svelte
@@ -86,7 +86,7 @@
 				/>
 				<span>
 					{user.github_name || user.github_login}
-					(<a on:click|preventDefault={logout} href="auth/logout">log out</a>)
+					(<a on:click|preventDefault={logout} href="/auth/logout">log out</a>)
 				</span>
 			</div>
 		</header>
@@ -136,7 +136,7 @@
 		{/if}
 	{:else}
 		<p>
-			Please <a on:click|preventDefault={login} href="auth/login">log in</a> to see your saved apps.
+			Please <a on:click|preventDefault={login} href="/auth/login">log in</a> to see your saved apps.
 		</p>
 	{/if}
 </div>

--- a/sites/svelte.dev/src/routes/examples/[slug]/_TableOfContents.svelte
+++ b/sites/svelte.dev/src/routes/examples/[slug]/_TableOfContents.svelte
@@ -34,7 +34,7 @@
 						<span>{example.name}</span>
 					</a>
 					{#if example.slug === active_section}
-						<a bind:this={active_el} href="repl/{example.slug}" class="repl-link">REPL</a>
+						<a bind:this={active_el} href="/repl/{example.slug}" class="repl-link">REPL</a>
 					{/if}
 				</div>
 			{/each}

--- a/sites/svelte.dev/src/routes/faq/_faqs.js
+++ b/sites/svelte.dev/src/routes/faq/_faqs.js
@@ -35,7 +35,7 @@ export default function get_faqs() {
 				return `
 					<h${level}>
 						<span id="${fragment}" class="offset-anchor"></span>
-						<a href="faq#${fragment}" class="anchor" aria-hidden="true"></a>
+						<a href="/faq#${fragment}" class="anchor" aria-hidden="true"></a>
 						${text}
 					</h${level}>`;
 			};

--- a/sites/svelte.dev/src/routes/faq/index.svelte
+++ b/sites/svelte.dev/src/routes/faq/index.svelte
@@ -32,7 +32,7 @@
 			<h2>
 				<span id={faq.slug} class="offset-anchor" />
 				{faq.title}
-				<Permalink href="faq#{faq.slug}" />
+				<Permalink href="/faq#{faq.slug}" />
 			</h2>
 			{@html faq.content}
 		</article>

--- a/sites/svelte.dev/src/routes/index.svelte
+++ b/sites/svelte.dev/src/routes/index.svelte
@@ -33,7 +33,7 @@
 				JavaScript
 			</p>
 
-			<a sveltekit:prefetch href="blog/write-less-code" class="cta">learn more</a>
+			<a sveltekit:prefetch href="/blog/write-less-code" class="cta">learn more</a>
 		</div>
 
 		<div slot="two">
@@ -43,7 +43,7 @@
 				stays fast
 			</p>
 
-			<a sveltekit:prefetch href="blog/virtual-dom-is-pure-overhead" class="cta">learn more</a>
+			<a sveltekit:prefetch href="/blog/virtual-dom-is-pure-overhead" class="cta">learn more</a>
 		</div>
 
 		<div slot="three">
@@ -52,7 +52,7 @@
 				No more complex state management libraries — Svelte brings reactivity to JavaScript itself
 			</p>
 
-			<a sveltekit:prefetch href="blog/svelte-3-rethinking-reactivity" class="cta">learn more</a>
+			<a sveltekit:prefetch href="/blog/svelte-3-rethinking-reactivity" class="cta">learn more</a>
 		</div>
 
 		<div class="description" slot="what">
@@ -77,7 +77,7 @@
 					>most satisfied developers</a
 				>
 				in a pair of industry surveys. We think you'll love it too.
-				<a href="blog/svelte-3-rethinking-reactivity" class="cta">Read the introductory blog post</a
+				<a href="/blog/svelte-3-rethinking-reactivity" class="cta">Read the introductory blog post</a
 				> to learn more.
 			</p>
 		</div>
@@ -91,11 +91,11 @@ npm run dev
 			</code></pre>
 
 			<p style="flex: 1">
-				See the <a href="blog/the-easiest-way-to-get-started">quickstart guide</a> for TypeScript support
+				See the <a href="/blog/the-easiest-way-to-get-started">quickstart guide</a> for TypeScript support
 				and more details.
 			</p>
 
-			<a sveltekit:prefetch href="tutorial" class="cta">Learn Svelte</a>
+			<a sveltekit:prefetch href="/tutorial" class="cta">Learn Svelte</a>
 		</div>
 	</Blurb>
 </div>

--- a/sites/svelte.dev/src/routes/repl/[id]/_components/AppControls/UserMenu.svelte
+++ b/sites/svelte.dev/src/routes/repl/[id]/_components/AppControls/UserMenu.svelte
@@ -16,7 +16,7 @@
 
 	{#if showMenu}
 		<div class="menu">
-			<a href="apps">Your saved apps</a>
+			<a href="/apps">Your saved apps</a>
 			<button on:click={logout}>Log out</button>
 		</div>
 	{/if}


### PR DESCRIPTION
`<base` tag was removed in #227 which makes links without `/` behaves differently, related to #229 