### PR TITLE
fix: h4s in docs overlay preceding text

### DIFF
--- a/packages/site-kit/src/lib/docs/Main.svelte
+++ b/packages/site-kit/src/lib/docs/Main.svelte
@@ -219,10 +219,6 @@
 		opacity: 0.7;
 	}
 
-	.content :global(h4 > .anchor) {
-		inset-block-start: 0.05em;
-	}
-
 	.content :global(h5) {
 		font-size: 2.4rem;
 		margin-block: 2em 0.5em;

--- a/packages/site-kit/src/lib/docs/Main.svelte
+++ b/packages/site-kit/src/lib/docs/Main.svelte
@@ -17,8 +17,8 @@
 				a.className = 'anchor';
 				a.href = `${$page.path}#${heading.id}`;
 				const span = document.createElement('span');
-				span.className = 'visually-hidden';
-				span.innerHTML = 'permalink';
+				span.className = "visually-hidden";
+				span.innerHTML = "permalink";
 				a.appendChild(span);
 				heading.appendChild(a);
 			}

--- a/packages/site-kit/src/lib/docs/Main.svelte
+++ b/packages/site-kit/src/lib/docs/Main.svelte
@@ -200,11 +200,11 @@
 		font-size: 2.4rem;
 		color: var(--second);
 		margin-inline: 0;
-		margin-block: -5.5rem 1.6rem;
+		margin-block: 6.4rem 1.6rem;
 		padding-inline-start: 0;
 		background: transparent;
 		line-height: 1;
-		padding-block-start: 10rem;
+		padding-block-start: 0;
 		inset-block-start: 0;
 	}
 

--- a/packages/site-kit/src/lib/docs/Main.svelte
+++ b/packages/site-kit/src/lib/docs/Main.svelte
@@ -17,8 +17,8 @@
 				a.className = 'anchor';
 				a.href = `${$page.path}#${heading.id}`;
 				const span = document.createElement('span');
-				span.className = "visually-hidden";
-				span.innerHTML = "permalink";
+				span.className = 'visually-hidden';
+				span.innerHTML = 'permalink';
 				a.appendChild(span);
 				heading.appendChild(a);
 			}
@@ -206,6 +206,13 @@
 		line-height: 1;
 		padding-block-start: 0;
 		inset-block-start: 0;
+	}
+
+	.content :global(h4::before) {
+		display: block;
+		content: ' ';
+		block-size: var(--nav-h);
+		margin-block-start: calc(-1 * var(--nav-h));
 	}
 
 	.content :global(h4 > em) {


### PR DESCRIPTION
Closes #246

Avoids #73 in a slightly different way, see https://nicolasgallagher.com/jump-links-and-viewport-positioning/demo/#method-B