### PR TITLE
add emmet plugin to the repl

### DIFF
--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -23,6 +23,7 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@emmetio/codemirror-plugin": "^1.2.4",
 		"@sveltejs/site-kit": "workspace:*",
 		"acorn": "^8.6.0",
 		"codemirror": "5",

--- a/packages/repl/src/lib/CodeMirror.svelte
+++ b/packages/repl/src/lib/CodeMirror.svelte
@@ -131,7 +131,7 @@
         CodeMirror = mod.default;
         emmet = (await import('@emmetio/codemirror-plugin')).default;
 			}
-      emmet(CodeMirror);
+      await emmet(CodeMirror);
       await createEditor(mode || 'svelte');
 			if (editor) editor.setValue(code || '');
 		})();

--- a/packages/repl/src/lib/CodeMirror.svelte
+++ b/packages/repl/src/lib/CodeMirror.svelte
@@ -89,6 +89,7 @@
 	let error_line;
 	let destroyed = false;
 	let CodeMirror;
+	let emmet;
 
 	$: if (editor && w && h) {
 		editor.refresh();
@@ -127,9 +128,11 @@
 		(async () => {
 			if (!CodeMirror) {
 				let mod = await import('./codemirror.js');
-				CodeMirror = mod.default;
+        CodeMirror = mod.default;
+        emmet = (await import('@emmetio/codemirror-plugin')).default;
 			}
-			await createEditor(mode || 'svelte');
+      await createEditor(mode || 'svelte');
+      emmet(CodeMirror);
 			if (editor) editor.setValue(code || '');
 		})();
 
@@ -170,7 +173,7 @@
 					cm.foldCode(cm.getCursor());
 				},
 				// allow escaping the CodeMirror with Esc Tab
-				'Esc Tab': false
+				'Tab': 'emmetExpandAbbreviation'
 			}),
 			foldGutter: true,
 			gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],

--- a/packages/repl/src/lib/CodeMirror.svelte
+++ b/packages/repl/src/lib/CodeMirror.svelte
@@ -131,8 +131,8 @@
         CodeMirror = mod.default;
         emmet = (await import('@emmetio/codemirror-plugin')).default;
 			}
-      await createEditor(mode || 'svelte');
       emmet(CodeMirror);
+      await createEditor(mode || 'svelte');
 			if (editor) editor.setValue(code || '');
 		})();
 


### PR DESCRIPTION
Adds [emmetio/codemirror-plugin ](https://github.com/emmetio/codemirror-plugin) to the repl editor, to add Emmet functionality.