### PR TITLE
fix undefined meta tags content

### DIFF
--- a/sites/svelte.dev/src/routes/tutorial/[slug]/index.svelte
+++ b/sites/svelte.dev/src/routes/tutorial/[slug]/index.svelte
@@ -117,8 +117,8 @@
 	<title>{selected.section.name} / {selected.chapter.name} • Svelte Tutorial</title>
 
 	<meta name="twitter:title" content="Svelte tutorial" />
-	<meta name="twitter:description" content="{selected.section.title} / {selected.chapter.title}" />
-	<meta name="Description" content="{selected.section.title} / {selected.chapter.title}" />
+	<meta name="twitter:description" content="{selected.section.name} / {selected.chapter.name}" />
+	<meta name="Description" content="{selected.section.name} / {selected.chapter.name}" />
 </svelte:head>
 
 <svelte:window bind:innerWidth={width} />


### PR DESCRIPTION
Changes the `twitter:description` and `Description` `meta` tags to use the same properties as those used in the `<title>` element just above it (which does work), to prevent them from showing as "undefined".

Fixes #259

PS. The PR has been created through the GitHub UI so the changes are not quite tested. But they seemed so straightforward that the PR (or at least the trace to the relevant file it has) might help?