### PR TITLE
Fix misalignment of link text and icon

### DIFF
--- a/sites/svelte.dev/src/routes/tutorial/[slug]/index.svelte
+++ b/sites/svelte.dev/src/routes/tutorial/[slug]/index.svelte
@@ -291,6 +291,7 @@
 		border-block-start: 1px solid rgba(255, 255, 255, 0.15);
 		padding-block-start: 1em;
 		display: flex;
+		align-items: center;
 	}
 
 	.show {


### PR DESCRIPTION
"Next" button and its icon aren't vertically aligned when the "Show Me" button is present.

For example: https://svelte.dev/tutorial/adding-data

Before:
<img width="401" alt="Screen Shot 2022-01-12 at 7 05 14 PM" src="https://user-images.githubusercontent.com/19195468/149247562-b00f75c0-d239-423f-b306-b74786acb915.png">

After:
<img width="401" alt="Screen Shot 2022-01-12 at 7 05 06 PM" src="https://user-images.githubusercontent.com/19195468/149247563-4b5fe567-7d4f-4ef0-bf84-b622f4e24e20.png">