### PR TITLE
Add limits to grid items

### DIFF
--- a/sites/svelte.dev/src/routes/_components/Supporters/index.svelte
+++ b/sites/svelte.dev/src/routes/_components/Supporters/index.svelte
@@ -62,7 +62,7 @@
 	.grid {
 		position: relative;
 		display: grid;
-		grid-template-columns: repeat(6, 1fr);
+		grid-template-columns: repeat(6, minmax(0, 1fr));
 		grid-gap: 1em;
 	}
 
@@ -96,13 +96,13 @@
 
 	@media (min-width: 480px) {
 		.grid {
-			grid-template-columns: repeat(8, 1fr);
+			grid-template-columns: repeat(8, minmax(0, 1fr));
 		}
 	}
 
 	@media (min-width: 720px) {
 		.grid {
-			grid-template-columns: repeat(12, 1fr);
+			grid-template-columns: repeat(12, minmax(0, 1fr));
 		}
 	}
 
@@ -128,20 +128,20 @@
 		.grid {
 			position: relative;
 			display: grid;
-			grid-template-columns: repeat(6, 1fr);
+			grid-template-columns: repeat(6, minmax(0, 1fr));
 			grid-gap: 1em;
 		}
 	}
 
 	@media (min-width: 880px) {
 		.grid {
-			grid-template-columns: repeat(8, 1fr);
+			grid-template-columns: repeat(8, minmax(0, 1fr));
 		}
 	}
 
 	@media (min-width: 1100px) {
 		.grid {
-			grid-template-columns: repeat(12, 1fr);
+			grid-template-columns: repeat(12, minmax(0, 1fr));
 		}
 	}
 


### PR DESCRIPTION
Prevents incorrectly sized items as seen in Safari
<img width="1440" alt="Screenshot 2022-01-20 at 8 28 46 pm" src="https://user-images.githubusercontent.com/2401925/150416975-2ec4c8d4-025f-4ab3-b4d1-e0b6ced0652e.png">

