### PR TITLE
Fix breaking change not handled for REPL endpoint

### DIFF
--- a/sites/svelte.dev/src/routes/repl/[id]/index.json.js
+++ b/sites/svelte.dev/src/routes/repl/[id]/index.json.js
@@ -6,7 +6,7 @@ let examples;
 
 function munge(files) {
 	return files
-		.map((file) => {
+		.map(file => {
 			const dot = file.name.lastIndexOf('.');
 			let name = file.name.slice(0, dot);
 			let type = file.name.slice(dot + 1);
@@ -29,9 +29,9 @@ export async function get({ params }) {
 		const res = await fetch(`${API_BASE}/docs/svelte/examples`);
 		examples = new Set(
 			(await res.json())
-				.map((category) => category.examples)
+				.map(category => category.examples)
 				.flat()
-				.map((example) => example.slug)
+				.map(example => example.slug)
 		);
 	}
 

--- a/sites/svelte.dev/src/routes/repl/[id]/index.json.js
+++ b/sites/svelte.dev/src/routes/repl/[id]/index.json.js
@@ -6,7 +6,7 @@ let examples;
 
 function munge(files) {
 	return files
-		.map(file => {
+		.map((file) => {
 			const dot = file.name.lastIndexOf('.');
 			let name = file.name.slice(0, dot);
 			let type = file.name.slice(dot + 1);
@@ -29,9 +29,9 @@ export async function get({ params }) {
 		const res = await fetch(`${API_BASE}/docs/svelte/examples`);
 		examples = new Set(
 			(await res.json())
-				.map(category => category.examples)
+				.map((category) => category.examples)
 				.flat()
-				.map(example => example.slug)
+				.map((example) => example.slug)
 		);
 	}
 
@@ -78,7 +78,7 @@ export async function get({ params }) {
 	};
 }
 
-export async function put({ locals, params, body }) {
+export async function put({ locals, params, request }) {
 	if (!locals.user) {
 		return {
 			status: 401,
@@ -86,6 +86,7 @@ export async function put({ locals, params, body }) {
 		};
 	}
 
+	const body = await request.json();
 	await gist.update(locals.user, params.id, body);
 
 	return {


### PR DESCRIPTION
#270 updated to the latest kit version and addressed breaking changes throughout the whole site, but @geoffrich must have overlooked this endpoint in the REPL.
Since saving REPLs is broken by this, I thought it would be fastest if I just straight into a PR.
Following the instructions to set up supabase and github oauth this works like a charm on localhost.
Much love <3 to all of you heroes working on the site