### PR TITLE
[chore] improve local REPL without local Supabase

### DIFF
--- a/sites/svelte.dev/README.md
+++ b/sites/svelte.dev/README.md
@@ -1,6 +1,10 @@
 ## Running locally
 
-Setup a database on [Supabase](https://supabase.com) with the instructions [here](../../db) and set the corresponding environment variables.
+A local database is only required in dev mode if you want to test reading and writing saved REPLs on it. Without a local database in dev mode, the REPL will be able to load saved REPLs from the production database, but not save them.
+
+Note also that in dev mode, the REPL will currently only work in Chrome, as noted in the Vite documentation [here](https://vitejs.dev/guide/features.html#web-workers), pending support in Firefox for `import` statements in web workers.
+
+If you do want to use a database, set it up on [Supabase](https://supabase.com) with the instructions [here](../../db) and set the corresponding environment variables.
 
 Run the site sub-project:
 

--- a/sites/svelte.dev/README.md
+++ b/sites/svelte.dev/README.md
@@ -2,7 +2,7 @@
 
 A local database is only required in dev mode if you want to test reading and writing saved REPLs on it. Without a local database in dev mode, the REPL will be able to load saved REPLs from the production database, but not save them.
 
-Note also that in dev mode, the REPL will currently only work in Chrome, as noted in the Vite documentation [here](https://vitejs.dev/guide/features.html#web-workers), pending support in Firefox for `import` statements in web workers.
+Note also that in dev mode, the REPL will currently only work in Chrome, [as noted in the Vite documentation](https://vitejs.dev/guide/features.html#web-workers), pending support in Firefox for `import` statements in web workers.
 
 If you do want to use a database, set it up on [Supabase](https://supabase.com) with the instructions [here](../../db) and set the corresponding environment variables.
 

--- a/sites/svelte.dev/src/lib/db/client.js
+++ b/sites/svelte.dev/src/lib/db/client.js
@@ -1,6 +1,8 @@
+import { dev } from '$app/env';
 import { createClient } from '@supabase/supabase-js';
 
-const SUPABASE_URL = process.env['SUPABASE_URL'];
-const SUPABASE_KEY = process.env['SUPABASE_KEY'];
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_KEY;
 
-export const client = createClient(SUPABASE_URL, SUPABASE_KEY, { fetch });
+export const client =
+	(!dev || (SUPABASE_URL && SUPABASE_KEY)) && createClient(SUPABASE_URL, SUPABASE_KEY, { fetch });

--- a/sites/svelte.dev/src/routes/repl/[id]/index.json.js
+++ b/sites/svelte.dev/src/routes/repl/[id]/index.json.js
@@ -1,3 +1,5 @@
+import { dev } from '$app/env';
+import { client } from '$lib/db/client';
 import * as gist from '$lib/db/gist';
 import { API_BASE } from '$lib/env';
 
@@ -56,6 +58,12 @@ export async function get({ params }) {
 				components: munge(example.files)
 			}
 		};
+	}
+
+	if (dev && !client) {
+		// in dev with no local Supabase configured, proxy to production
+		// this lets us at least load saved REPLs
+		return fetch(`https://svelte.dev/repl/${params.id}.json`);
 	}
 
 	const app = await gist.read(params.id);


### PR DESCRIPTION
This is a followup to #273 and makes running the svelte.dev site locally a bit easier, for the benefit of folks who want to try out local copies of the compiler on saved REPLs (say, on one given as a repro for an open issue).

In dev mode, you are no longer required to set the `SUPABASE_` env vars, and attempting to load a REPL without them set will instead proxy the request to the production svelte.dev, similar to what happened in the old version of the Svelte site.

This also updates the readme for svelte.dev slightly with appropriate information.