### PR TITLE
[docs] make FAQ code blocks match rest of site

### DIFF
--- a/sites/svelte.dev/src/routes/faq/index.svelte
+++ b/sites/svelte.dev/src/routes/faq/index.svelte
@@ -61,7 +61,6 @@
 		margin: 0;
 		inset-block-start: 0;
 		background: transparent;
-		color: white;
 	}
 
 	.faqs :global(pre) {
@@ -71,7 +70,6 @@
 		max-inline-size: var(--linemax);
 		padding-inline: 2.5rem;
 		padding-block: 1.5rem;
-		background: #333;
 		border-radius: 0.5rem;
 		font-size: 0.8rem;
 	}


### PR DESCRIPTION
See https://github.com/sveltejs/kit/pull/3794#issuecomment-1033963412 for context

Remove custom code block styles on svelte.dev FAQ page, so that it matches the rest of the svelte sites.