### PR TITLE
Add syntax higlighting styles to FAQ

### DIFF
--- a/sites/svelte.dev/src/routes/faq/index.svelte
+++ b/sites/svelte.dev/src/routes/faq/index.svelte
@@ -13,6 +13,7 @@
 
 <script>
 	import { Permalink } from '@sveltejs/site-kit';
+	import '@sveltejs/site-kit/code.css';
 
 	export let faqs;
 </script>


### PR DESCRIPTION
Followup to https://github.com/sveltejs/sites/pull/297

The code block CSS was not imported on the FAQ page, so the styles weren't applied when loading the page directly.