### PR TITLE
fix: Ensure text remains visible during webfont load

### DIFF
--- a/packages/site-kit/src/lib/base.css
+++ b/packages/site-kit/src/lib/base.css
@@ -79,6 +79,7 @@ body {
 	font-weight: 300;
 	src: local('Overpass Light '), local('Overpass-Light'),
 		url('./fonts/overpass/overpass-latin-300.woff2') format('woff2');
+	font-display: swap;
 }
 
 /* overpass-600normal - latin */
@@ -88,6 +89,7 @@ body {
 	font-weight: 600;
 	src: local('Overpass Bold '), local('Overpass-Bold'),
 		url('./fonts/overpass/overpass-latin-600.woff2') format('woff2');
+	font-display: swap;
 }
 
 /* fira-mono-400normal - latin */


### PR DESCRIPTION
https://web.dev/font-display/?utm_source=lighthouse&utm_medium=devtools