### PR TITLE
Remove horizontal padding of range input

### DIFF
--- a/packages/repl/src/lib/Output/srcdoc/index.html
+++ b/packages/repl/src/lib/Output/srcdoc/index.html
@@ -49,6 +49,10 @@
 				border-radius: 2px;
 			}
 
+			input[type=range] {
+				padding: 0.4em 0;
+			}
+
 			input:disabled {
 				color: #ccc;
 			}


### PR DESCRIPTION
Remove the horizontal padding of range input, that can lead to thinking that we can't reach the minimum value and maximum value.

Linked thread on Discord: https://discord.com/channels/457912077277855764/945764520654151800