### PR TITLE
fix: remove vertical-align for a block element

### DIFF
--- a/packages/repl/src/lib/Output/CompilerOptions.svelte
+++ b/packages/repl/src/lib/Output/CompilerOptions.svelte
@@ -133,7 +133,6 @@
 		height: 15px;
 		margin-left: -21px;
 		margin-top: 4px;
-		vertical-align: top;
 		cursor: pointer;
 		text-align: center;
 		transition: box-shadow 0.1s ease-out;


### PR DESCRIPTION
I believe `vertical-align` is for `inline`, `inline-block` or `table-cell` elements.  Probably not necessary to set `vertical-align` here since `display: block` is set for `input[type='radio'] + label:before`🤔☺️.

> The vertical-align [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) property sets vertical alignment of an inline, inline-block or table-cell box.

https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align#vertical_alignment_in_a_line_box