### PR TITLE
Replace `create-svelte` readme content in `packages/repl/README.md`

### DIFF
--- a/packages/repl/README.md
+++ b/packages/repl/README.md
@@ -1,38 +1,13 @@
-# create-svelte
+# @sveltejs/svelte-repl
 
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte);
+This is the guts of https://svelte.dev/repl, extracted into its own package so that it can be used elsewhere.
 
-## Creating a project
+## TODO
 
-If you're seeing this, you've probably already done this step. Congrats!
+* Documentation
+* Tests
+* Themeability
 
-```bash
-# create a new project in the current directory
-npm init svelte@next
+## License
 
-# create a new project in my-app
-npm init svelte@next my-app
-```
-
-> Note: the `@next` is temporary
-
-## Developing
-
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
-
-```bash
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
-```
-
-## Building
-
-Before creating a production version of your app, install an [adapter](https://kit.svelte.dev/docs#adapters) for your target environment. Then:
-
-```bash
-npm run build
-```
-
-> You can preview the built app with `npm run preview`, regardless of whether you installed an adapter. This should _not_ be used to serve your app in production.
+[MIT](LICENSE)


### PR DESCRIPTION
Use former readme content from now-archived https://github.com/sveltejs/svelte-repl/commit/64a9e30519c30f356c2e65c527fbe4c8e980184f.