### PR TITLE
Fix: Height in zen-mode

### DIFF
--- a/sites/svelte.dev/src/routes/__layout.svelte
+++ b/sites/svelte.dev/src/routes/__layout.svelte
@@ -153,6 +153,10 @@
 		bottom: var(--ukr-footer-height) !important;
 	}
 
+	:global(.zen-mode) {
+		height: calc(100vh - var(--ukr-footer-height)) !important;
+	}
+
 	@media (max-width: 830px) {
 		:global(aside) {
 			z-index: 9999 !important;


### PR DESCRIPTION
There was white space below `Repl` in zen-mode.

Before| After
--- | ---
<img width="1433" alt="Screen Shot 2022-03-25 at 2 05 35 PM" src="https://user-images.githubusercontent.com/32632542/160058484-7dc24c1c-3d12-44f2-a4df-643a7902232d.png">| <img width="1432" alt="image" src="https://user-images.githubusercontent.com/32632542/160057716-7160f655-9eac-4b65-84e8-84d85a506fb4.png">


Fix of #315

