### PR TITLE
fix: Design of AST output

### DIFF
--- a/packages/repl/src/lib/Output/AstNode.svelte
+++ b/packages/repl/src/lib/Output/AstNode.svelte
@@ -61,7 +61,7 @@
 	on:mouseleave={handle_unmark_text}
 >
 	{#if !is_root && is_collapsable}
-		<button class="toggle" class:open={!collapsed} on:click={() => (collapsed = !collapsed)}>
+		<button class="ast-toggle" class:open={!collapsed} on:click={() => (collapsed = !collapsed)}>
 			{key_text}
 		</button>
 	{:else if key_text}
@@ -108,11 +108,11 @@
 		text-decoration: underline;
 	}
 
-	.toggle {
+	.ast-toggle {
 		position: relative;
 	}
 
-	.toggle::before {
+	.ast-toggle::before {
 		content: '\25B6';
 		position: absolute;
 		bottom: 0;
@@ -120,7 +120,7 @@
 		opacity: 0.7;
 	}
 
-	.toggle.open::before {
+	.ast-toggle.open::before {
 		content: '\25BC';
 	}
 


### PR DESCRIPTION
## Description
There was a class called `toggle` in `src/lib/Output/AstNode.svelte`. And it was affected by the code below.

```css
/* sites/svelte.dev/src/routes/__layout.svelte */
:global(.toggle) {
  bottom: var(--ukr-footer-height) !important;
}
```

I just changed the class name in `AstNode.svelte`.  Plz let me know if there is a preferred way to handle this. 

fix of  #317

