### PR TITLE
fix build error with svelte-json-tree

### DIFF
--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -22,6 +22,7 @@
 		"typescript": "^4.5.5"
 	},
 	"type": "module",
+	"svelte": "./src/lib/index.js",
 	"dependencies": {
 		"@sveltejs/site-kit": "workspace:*",
 		"acorn": "^8.7.0",


### PR DESCRIPTION
i'm not quite sure what happened, but @bluwy suggested to add `"svelte"` entry to `@sveltejs/repl`