### PR TITLE
Fix console.assert

### DIFF
--- a/packages/repl/src/lib/Output/srcdoc/index.html
+++ b/packages/repl/src/lib/Output/srcdoc/index.html
@@ -231,12 +231,12 @@
 			};
 
 			const original_assert = console.assert;
-			console.assert = (condition, ...args) => {
-				if (condition) {
+			console.assert = (assertion, ...args) => {
+				if (!assertion) {
 					const stack = new Error().stack;
 					parent.postMessage({ action: 'console', level: 'assert', args, stack }, '*');
 				}
-				original_assert(condition, ...args);
+				original_assert(assertion, ...args);
 			};
 
 			const counter = new Map();


### PR DESCRIPTION
Console.assert should only log when its first variable is false. In the current situation it logs to the in-REPL console only in the true case.

I renamed the variable to better reflect what its doing (thinking about it as an assertion rather than a condition hints at its use).