### PR TITLE
chore: update to pnpm7 and enforce using it

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 link-workspace-packages = true
 shamefully-hoist = true
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
 		"@changesets/cli": "^2.20.0"
 	},
 	"scripts": {
-		"release": "pnpm publish --tag=next --filter=\"@sveltejs/*\""
+		"release": "pnpm --filter=\"@sveltejs/*\" publish --tag=next"
+	},
+	"packageManager": "pnpm@7.1.0",
+	"engines": {
+		"pnpm": "^7.1.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
 	},
 	"packageManager": "pnpm@7.1.0",
 	"engines": {
-		"pnpm": "^7.1.0"
+		"pnpm": "^7.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -36,15 +36,15 @@ importers:
       svelte-json-tree: 1.0.0
       yootils: 0.3.1
     devDependencies:
-      '@sveltejs/adapter-auto': 1.0.0-next.34
-      '@sveltejs/kit': 1.0.0-next.306_svelte@3.46.3
+      '@sveltejs/adapter-auto': 1.0.0-next.40
+      '@sveltejs/kit': 1.0.0-next.328_svelte@3.46.3
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0_eslint@7.32.0
-      eslint-plugin-svelte3: 3.4.0_eslint@7.32.0+svelte@3.46.3
+      eslint-plugin-svelte3: 3.4.0_62nep34oqm5xi3754v6jtqj4gq
       prettier: 2.5.1
-      prettier-plugin-svelte: 2.6.0_prettier@2.5.1+svelte@3.46.3
+      prettier-plugin-svelte: 2.6.0_4eyexd7fan5mewltwswdk63sd4
       svelte: 3.46.3
-      svelte2tsx: 0.4.14_svelte@3.46.3+typescript@4.5.5
+      svelte2tsx: 0.4.14_27j3ltjomj5oinnll263juekly
       typescript: 4.5.5
 
   packages/site-kit:
@@ -57,9 +57,9 @@ importers:
     dependencies:
       golden-fleece: 1.0.9
     devDependencies:
-      '@sveltejs/kit': 1.0.0-next.306_svelte@3.46.3
+      '@sveltejs/kit': 1.0.0-next.328_svelte@3.46.3
       svelte: 3.46.3
-      svelte2tsx: 0.4.14_svelte@3.46.3+typescript@4.5.5
+      svelte2tsx: 0.4.14_27j3ltjomj5oinnll263juekly
       typescript: 4.5.5
 
   sites/hn.svelte.dev:
@@ -70,10 +70,10 @@ importers:
       prettier-plugin-svelte: ^2.6.0
       svelte: ^3.46.3
     devDependencies:
-      '@sveltejs/adapter-auto': 1.0.0-next.34
-      '@sveltejs/kit': 1.0.0-next.306_svelte@3.46.3
+      '@sveltejs/adapter-auto': 1.0.0-next.40
+      '@sveltejs/kit': 1.0.0-next.328_svelte@3.46.3
       prettier: 2.5.1
-      prettier-plugin-svelte: 2.6.0_prettier@2.5.1+svelte@3.46.3
+      prettier-plugin-svelte: 2.6.0_4eyexd7fan5mewltwswdk63sd4
       svelte: 3.46.3
 
   sites/svelte.dev:
@@ -106,15 +106,15 @@ importers:
       flru: 1.0.2
       marked: 4.0.12
     devDependencies:
-      '@sveltejs/adapter-auto': 1.0.0-next.34
-      '@sveltejs/kit': 1.0.0-next.306_svelte@3.46.3
+      '@sveltejs/adapter-auto': 1.0.0-next.40
+      '@sveltejs/kit': 1.0.0-next.328_svelte@3.46.3
       '@sveltejs/site-kit': link:../../packages/site-kit
       degit: 2.8.4
       dotenv: 10.0.0
       jimp: 0.8.5
       node-fetch: 2.6.7
       prettier: 2.5.1
-      prettier-plugin-svelte: 2.6.0_prettier@2.5.1+svelte@3.46.3
+      prettier-plugin-svelte: 2.6.0_4eyexd7fan5mewltwswdk63sd4
       shelljs: 0.8.5
       svelte: 3.46.3
       vite-imagetools: 4.0.3
@@ -448,7 +448,7 @@ packages:
       tinycolor2: 1.4.2
     dev: true
 
-  /@jimp/plugin-contain/0.8.5_7b3442c1f9aaa6a8602c0ed67a0f3a25:
+  /@jimp/plugin-contain/0.8.5_pm2efqpzvktkqybmb3lhudz2eu:
     resolution: {integrity: sha512-ZkiPFx9L0yITiKtYTYLWyBsSIdxo/NARhNPRZXyVF9HmTWSLDUw1c2c1uvETKxDZTAVK+souYT14DwFWWdhsYA==}
     peerDependencies:
       '@jimp/custom': '>=0.3.5'
@@ -459,12 +459,12 @@ packages:
       '@jimp/custom': 0.8.5
       '@jimp/plugin-blit': 0.8.5_@jimp+custom@0.8.5
       '@jimp/plugin-resize': 0.8.5_@jimp+custom@0.8.5
-      '@jimp/plugin-scale': 0.8.5_142bac235093407dd26a534350adee8e
+      '@jimp/plugin-scale': 0.8.5_cqv2yi2qsnah3utkknbvblpory
       '@jimp/utils': 0.8.5
       core-js: 2.6.12
     dev: true
 
-  /@jimp/plugin-cover/0.8.5_cffab90967f4c556c3b218b5fc20311c:
+  /@jimp/plugin-cover/0.8.5_z75lsclh6tcvnq5sdc27yibrdq:
     resolution: {integrity: sha512-OdT4YAopLOhbhTUQV3R1v5ZZqIaUt3n3vJi/OfTbsak1t9UkPBVdmYPyhoont8zJdtdkF5dW16Ro1FTshytcww==}
     peerDependencies:
       '@jimp/custom': '>=0.3.5'
@@ -475,7 +475,7 @@ packages:
       '@jimp/custom': 0.8.5
       '@jimp/plugin-crop': 0.8.5_@jimp+custom@0.8.5
       '@jimp/plugin-resize': 0.8.5_@jimp+custom@0.8.5
-      '@jimp/plugin-scale': 0.8.5_142bac235093407dd26a534350adee8e
+      '@jimp/plugin-scale': 0.8.5_cqv2yi2qsnah3utkknbvblpory
       '@jimp/utils': 0.8.5
       core-js: 2.6.12
     dev: true
@@ -510,14 +510,14 @@ packages:
       core-js: 2.6.12
     dev: true
 
-  /@jimp/plugin-flip/0.8.5_5c8a5adef45e1f35ceff89ba15e57c83:
+  /@jimp/plugin-flip/0.8.5_lsffvxxulyptltx7rg5blzl4qm:
     resolution: {integrity: sha512-2QbGDkurPNAXZUeHLo/UA3tjh+AbAXWZKSdtoa1ArlASovRz8rqtA45YIRIkKrMH82TA3PZk8bgP2jaLKLrzww==}
     peerDependencies:
       '@jimp/custom': '>=0.3.5'
       '@jimp/plugin-rotate': '>=0.3.5'
     dependencies:
       '@jimp/custom': 0.8.5
-      '@jimp/plugin-rotate': 0.8.5_fd4e39e3f1a79af407011363f2e6137a
+      '@jimp/plugin-rotate': 0.8.5_7vhdty7ru6npibybcnr7fzqtpi
       '@jimp/utils': 0.8.5
       core-js: 2.6.12
     dev: true
@@ -562,7 +562,7 @@ packages:
       core-js: 2.6.12
     dev: true
 
-  /@jimp/plugin-print/0.8.5_3f7c805da8772e589a9493aa3217eaba:
+  /@jimp/plugin-print/0.8.5_h56iaxnio4xfrguusovdef7kxi:
     resolution: {integrity: sha512-BviNpCiA/fEieOqsrWr1FkqyFuiG2izdyyg7zUqyeUTHPwqrTLvXO9cfP/ThG4hZpu5wMQ5QClWSqhZu1fAwxA==}
     peerDependencies:
       '@jimp/custom': '>=0.3.5'
@@ -585,7 +585,7 @@ packages:
       core-js: 2.6.12
     dev: true
 
-  /@jimp/plugin-rotate/0.8.5_fd4e39e3f1a79af407011363f2e6137a:
+  /@jimp/plugin-rotate/0.8.5_7vhdty7ru6npibybcnr7fzqtpi:
     resolution: {integrity: sha512-8T9wnL3gb+Z0ogMZmtyI6h3y7TuqW2a5SpFbzFUVF+lTZoAabXjEfX3CAozizCLaT+Duc5H2FJVemAHiyr+Dbw==}
     peerDependencies:
       '@jimp/custom': '>=0.3.5'
@@ -601,7 +601,7 @@ packages:
       core-js: 2.6.12
     dev: true
 
-  /@jimp/plugin-scale/0.8.5_142bac235093407dd26a534350adee8e:
+  /@jimp/plugin-scale/0.8.5_cqv2yi2qsnah3utkknbvblpory:
     resolution: {integrity: sha512-G+CDH9s7BsxJ4b+mKZ5SsiXwTAynBJ+7/9SwZFnICZJJvLd79Tws6VPXfSaKJZuWnGIX++L8jTGmFORCfLNkdg==}
     peerDependencies:
       '@jimp/custom': '>=0.3.5'
@@ -622,20 +622,20 @@ packages:
       '@jimp/plugin-blit': 0.8.5_@jimp+custom@0.8.5
       '@jimp/plugin-blur': 0.8.5_@jimp+custom@0.8.5
       '@jimp/plugin-color': 0.8.5_@jimp+custom@0.8.5
-      '@jimp/plugin-contain': 0.8.5_7b3442c1f9aaa6a8602c0ed67a0f3a25
-      '@jimp/plugin-cover': 0.8.5_cffab90967f4c556c3b218b5fc20311c
+      '@jimp/plugin-contain': 0.8.5_pm2efqpzvktkqybmb3lhudz2eu
+      '@jimp/plugin-cover': 0.8.5_z75lsclh6tcvnq5sdc27yibrdq
       '@jimp/plugin-crop': 0.8.5_@jimp+custom@0.8.5
       '@jimp/plugin-displace': 0.8.5_@jimp+custom@0.8.5
       '@jimp/plugin-dither': 0.8.5_@jimp+custom@0.8.5
-      '@jimp/plugin-flip': 0.8.5_5c8a5adef45e1f35ceff89ba15e57c83
+      '@jimp/plugin-flip': 0.8.5_lsffvxxulyptltx7rg5blzl4qm
       '@jimp/plugin-gaussian': 0.8.5_@jimp+custom@0.8.5
       '@jimp/plugin-invert': 0.8.5_@jimp+custom@0.8.5
       '@jimp/plugin-mask': 0.8.5_@jimp+custom@0.8.5
       '@jimp/plugin-normalize': 0.8.5_@jimp+custom@0.8.5
-      '@jimp/plugin-print': 0.8.5_3f7c805da8772e589a9493aa3217eaba
+      '@jimp/plugin-print': 0.8.5_h56iaxnio4xfrguusovdef7kxi
       '@jimp/plugin-resize': 0.8.5_@jimp+custom@0.8.5
-      '@jimp/plugin-rotate': 0.8.5_fd4e39e3f1a79af407011363f2e6137a
-      '@jimp/plugin-scale': 0.8.5_142bac235093407dd26a534350adee8e
+      '@jimp/plugin-rotate': 0.8.5_7vhdty7ru6npibybcnr7fzqtpi
+      '@jimp/plugin-scale': 0.8.5_cqv2yi2qsnah3utkknbvblpory
       core-js: 2.6.12
       timm: 1.7.1
     dev: true
@@ -760,6 +760,8 @@ packages:
     dependencies:
       '@types/websocket': 1.0.5
       websocket: 1.0.34
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@supabase/storage-js/1.5.1:
@@ -779,45 +781,47 @@ packages:
       '@supabase/storage-js': 1.5.1
     transitivePeerDependencies:
       - encoding
+      - supports-color
     dev: false
 
-  /@sveltejs/adapter-auto/1.0.0-next.34:
-    resolution: {integrity: sha512-BzZVfy39idFojauroLrE/v9paJ1/HOlS2R857ooCwaLg+RrRy6zJHWwYxNSv5e8AaZiVg7ioZZpU/2g6ZgUpaQ==}
+  /@sveltejs/adapter-auto/1.0.0-next.40:
+    resolution: {integrity: sha512-TT6YJUF3asJ/2RbviEpcDJQ/TixPcvmH0L2266fGNT7+KfAf9wbbVdegPWRODk2E2hTN0X+h5YS9l+lap+BK9w==}
     dependencies:
-      '@sveltejs/adapter-cloudflare': 1.0.0-next.17
-      '@sveltejs/adapter-netlify': 1.0.0-next.51
-      '@sveltejs/adapter-vercel': 1.0.0-next.47
+      '@sveltejs/adapter-cloudflare': 1.0.0-next.19
+      '@sveltejs/adapter-netlify': 1.0.0-next.56
+      '@sveltejs/adapter-vercel': 1.0.0-next.50
     dev: true
 
-  /@sveltejs/adapter-cloudflare/1.0.0-next.17:
-    resolution: {integrity: sha512-B2ze5L0LsHFsZctVNy4sw0XxgV2YiVEHyMrWRo3pmpTwpu6GT5V3U2fsEoCMg/RKMazlWkyKTCuUqmcpYjjf2g==}
+  /@sveltejs/adapter-cloudflare/1.0.0-next.19:
+    resolution: {integrity: sha512-LET3DUYpl+deoKhkWCzhHUT7iipYkgVkOcRIJX7qT4m23A+MAbzcAC3npgwEYSe9RokOSWMVBr3tVujeES5EeA==}
     dependencies:
       esbuild: 0.14.31
-      worktop: 0.8.0-next.12
+      worktop: 0.8.0-next.13
     dev: true
 
-  /@sveltejs/adapter-netlify/1.0.0-next.51:
-    resolution: {integrity: sha512-P7/cW/0z8zd8J6DOI2yxKZG0+HRMMuzfOf0yzFXX0vRwBePhKlZ/H4qhTOo2NrCmj3Len545o+ugj5gyMXl1+g==}
+  /@sveltejs/adapter-netlify/1.0.0-next.56:
+    resolution: {integrity: sha512-fM3aBHsr7syCGfIJcuB1mEoZwynqyOxVijvmyrd9OWHi6MP3bXSP+GhKDMtDpQRwejJJiwuZNTx2PUbV3uirvA==}
     dependencies:
       '@iarna/toml': 2.2.5
       esbuild: 0.14.31
       tiny-glob: 0.2.9
     dev: true
 
-  /@sveltejs/adapter-vercel/1.0.0-next.47:
-    resolution: {integrity: sha512-VV3vP8KqL9XOc7xfQLVhXTM5jrTme+r1qJy98u5/dhAhkdjqrGDwAKo/s7MoB3rTYxLb2b8I4QxAaoz2Y2aIBg==}
+  /@sveltejs/adapter-vercel/1.0.0-next.50:
+    resolution: {integrity: sha512-yta0AkuWEr7qrm8LB34F4ZdCtMxj+cHD4huwrRYCgjv+PSJHLPwe7aH53+Mhrv6La0TgeyQ/f2lTyhBMXZXn9Q==}
     dependencies:
       esbuild: 0.14.31
     dev: true
 
-  /@sveltejs/kit/1.0.0-next.306_svelte@3.46.3:
-    resolution: {integrity: sha512-dLHoGTr4uwdHuI318O0jLDLOHaLsR2tZHQJLmf1+29H3tL79Kch4B4XCichJ0yIQFrnNATjNBYttM19POW4pyA==}
+  /@sveltejs/kit/1.0.0-next.328_svelte@3.46.3:
+    resolution: {integrity: sha512-L1RJ7wwLkOgo7aE+JiYppJEtVsSIpGPfgBZtjrS3J0avXVYUSTy+AfXbvjFJxTdk94uuCcTLUk/0vVODFm+Khg==}
     engines: {node: '>=14.13'}
     hasBin: true
     peerDependencies:
       svelte: ^3.44.0
     dependencies:
       '@sveltejs/vite-plugin-svelte': 1.0.0-next.40_svelte@3.46.3+vite@2.9.1
+      chokidar: 3.5.3
       sade: 1.8.1
       svelte: 3.46.3
       vite: 2.9.1
@@ -954,6 +958,14 @@ packages:
     resolution: {integrity: sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==}
     dev: true
 
+  /anymatch/3.1.2:
+    resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+    dev: true
+
   /aproba/1.2.0:
     resolution: {integrity: sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==}
     dev: true
@@ -999,6 +1011,11 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       is-windows: 1.0.2
+    dev: true
+
+  /binary-extensions/2.2.0:
+    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    engines: {node: '>=8'}
     dev: true
 
   /bl/4.1.0:
@@ -1099,6 +1116,21 @@ packages:
 
   /chardet/0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+    dev: true
+
+  /chokidar/3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.2
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /chownr/1.1.4:
@@ -1245,6 +1277,11 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
@@ -1642,7 +1679,7 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-plugin-svelte3/3.4.0_eslint@7.32.0+svelte@3.46.3:
+  /eslint-plugin-svelte3/3.4.0_62nep34oqm5xi3754v6jtqj4gq:
     resolution: {integrity: sha512-MIQUTuRv3o7LyQ+360qOc9mLT35j1I5YzHr04g/UDcvJTpg0X/kHWELY99ve869Rp/9wjqD7I26Aq5H8OH5RIg==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -2130,6 +2167,13 @@ packages:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
     dev: true
 
+  /is-binary-path/2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+    dependencies:
+      binary-extensions: 2.2.0
+    dev: true
+
   /is-ci/3.0.1:
     resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
     hasBin: true
@@ -2544,6 +2588,11 @@ packages:
       validate-npm-package-license: 3.0.4
     dev: true
 
+  /normalize-path/3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /npmlog/4.1.2:
     resolution: {integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==}
     dependencies:
@@ -2791,7 +2840,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-svelte/2.6.0_prettier@2.5.1+svelte@3.46.3:
+  /prettier-plugin-svelte/2.6.0_4eyexd7fan5mewltwswdk63sd4:
     resolution: {integrity: sha512-NPSRf6Y5rufRlBleok/pqg4+1FyGsL0zYhkYP6hnueeL1J/uCm3OfOZPsLX4zqD9VAdcXfyEL2PYqGv8ZoOSfA==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
@@ -2910,6 +2959,13 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    dev: true
+
+  /readdirp/3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
     dev: true
 
   /rechoir/0.6.2:
@@ -3296,7 +3352,7 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /svelte2tsx/0.4.14_svelte@3.46.3+typescript@4.5.5:
+  /svelte2tsx/0.4.14_27j3ltjomj5oinnll263juekly:
     resolution: {integrity: sha512-udF0Z/DA98OfjPFBU1GBJRpYHEvsxA8ozwYVN08AOWMnQyxoSyWWlYspiq2m9xAjLo/pWnhec9z1d6jc9umqjA==}
     peerDependencies:
       svelte: ^3.24
@@ -3547,6 +3603,8 @@ packages:
       typedarray-to-buffer: 3.1.5
       utf-8-validate: 5.0.8
       yaeti: 0.0.6
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /whatwg-url/5.0.0:
@@ -3593,8 +3651,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /worktop/0.8.0-next.12:
-    resolution: {integrity: sha512-ZXdgI9XOf0uB4IegFoViLdQ0Bf7hish0XMHwuV3nopOXygfLJkwAC5+HyA+sihBMSM2sLLQ5uGnD5aknL8+NQg==}
+  /worktop/0.8.0-next.13:
+    resolution: {integrity: sha512-aLPWSneFtPJr3RAf841orF9GNlVdVkQd2Wj/BbcGHp3whBZoXx6dcwwClA9fezm7muNan4SuT+ZTyMWdoJSCAg==}
     engines: {node: '>=12'}
     dependencies:
       mrmime: 1.0.0

--- a/sites/svelte.dev/src/routes/docs/index.svelte
+++ b/sites/svelte.dev/src/routes/docs/index.svelte
@@ -5,7 +5,9 @@
 		const sections = await fetch(`${API_BASE}/docs/svelte/docs?content`).then((r) => r.json());
 		return {
 			props: { sections },
-			maxage: 60
+			cache: {
+				maxage: 60
+			}
 		};
 	}
 </script>

--- a/sites/svelte.dev/src/routes/examples/[slug]/index.svelte
+++ b/sites/svelte.dev/src/routes/examples/[slug]/index.svelte
@@ -12,7 +12,9 @@
 				example: await example.json(),
 				slug: params.slug
 			},
-			maxage: 60
+			cache: {
+				maxage: 60
+			}
 		};
 	}
 </script>

--- a/sites/svelte.dev/src/routes/examples/__layout.svelte
+++ b/sites/svelte.dev/src/routes/examples/__layout.svelte
@@ -8,7 +8,9 @@
 			props: {
 				examples
 			},
-			maxage: 60
+			cache: {
+				maxage: 60
+			}
 		};
 	}
 </script>

--- a/sites/svelte.dev/src/routes/faq/index.svelte
+++ b/sites/svelte.dev/src/routes/faq/index.svelte
@@ -6,7 +6,9 @@
 
 		return {
 			props: { faqs },
-			maxage: 60
+			cache: {
+				maxage: 60
+			}
 		};
 	}
 </script>

--- a/sites/svelte.dev/src/routes/tutorial/[slug]/index.svelte
+++ b/sites/svelte.dev/src/routes/tutorial/[slug]/index.svelte
@@ -13,7 +13,9 @@
 
 		return {
 			props: { tutorial: await tutorial.json(), slug: params.slug },
-			maxage: 60
+			cache: {
+				maxage: 60
+			}
 		};
 	}
 </script>

--- a/sites/svelte.dev/src/routes/tutorial/__layout.svelte
+++ b/sites/svelte.dev/src/routes/tutorial/__layout.svelte
@@ -8,7 +8,9 @@
 			props: {
 				tutorials
 			},
-			maxage: 60
+			cache: {
+				maxage: 60
+			}
 		};
 	}
 </script>


### PR DESCRIPTION
unfortunately `pnpm install` decided to update a lot of versions in the lockfile, notably kit itself made a sizable jump. Needs to be verified if thats ok.

regarding the filter change: 
https://pnpm.io/cli/publish#--filter-package_selector links to https://pnpm.io/filtering which shows --filter before the command

engine-strict and packageManager are helpers to ensure pnpm7 is used