### PR TITLE
allow embedding svelte.dev on cross-origin-isolated sites

### DIFF
--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -22,20 +22,9 @@ self.addEventListener('message', async (event) => {
 			packagesUrl = event.data.packagesUrl;
 			svelteUrl = event.data.svelteUrl;
 
-			try {
-				importScripts(`${svelteUrl}/compiler.js`);
-			} catch (e) {
-				console.error('error in importScripts', e);
-
-				try {
-					await import(/* @vite-ignore */ `${svelteUrl}/compiler.js`);
-				} catch (e) {
-					console.error('error in await import', e);
-					const res = await fetch(`${svelteUrl}/compiler.js`);
-					const fn = new Function(await res.text());
-					fn();
-				}
-			}
+			const res = await fetch(`${svelteUrl}/compiler.js`);
+			const fn = new Function(await res.text());
+			fn();
 
 			fulfil_ready();
 			break;

--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -26,7 +26,15 @@ self.addEventListener('message', async (event) => {
 				importScripts(`${svelteUrl}/compiler.js`);
 			} catch (e) {
 				console.error('error in importScripts', e);
-				await import(/* @vite-ignore */ `${svelteUrl}/compiler.js`);
+
+				try {
+					await import(/* @vite-ignore */ `${svelteUrl}/compiler.js`);
+				} catch (e) {
+					console.error('error in await import', e);
+					const res = await fetch(`${svelteUrl}/compiler.js`);
+					const fn = new Function(await res.text());
+					fn();
+				}
 			}
 
 			fulfil_ready();

--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -24,7 +24,8 @@ self.addEventListener('message', async (event) => {
 
 			try {
 				importScripts(`${svelteUrl}/compiler.js`);
-			} catch {
+			} catch (e) {
+				console.error('error in importScripts', e);
 				await import(/* @vite-ignore */ `${svelteUrl}/compiler.js`);
 			}
 

--- a/packages/repl/src/lib/workers/compiler/index.js
+++ b/packages/repl/src/lib/workers/compiler/index.js
@@ -12,7 +12,15 @@ self.addEventListener('message', async (event) => {
 				importScripts(`${event.data.svelteUrl}/compiler.js`);
 			} catch (e) {
 				console.error('error in importScripts', e);
-				await import(/* @vite-ignore */ `${event.data.svelteUrl}/compiler.js`);
+
+				try {
+					await import(/* @vite-ignore */ `${event.data.svelteUrl}/compiler.js`);
+				} catch (e) {
+					console.error('error in await import', e);
+					const res = await fetch(`${event.data.svelteUrl}/compiler.js`);
+					const fn = new Function(await res.text());
+					fn();
+				}
 			}
 
 			fulfil_ready();

--- a/packages/repl/src/lib/workers/compiler/index.js
+++ b/packages/repl/src/lib/workers/compiler/index.js
@@ -8,20 +8,9 @@ const ready = new Promise((f) => {
 self.addEventListener('message', async (event) => {
 	switch (event.data.type) {
 		case 'init':
-			try {
-				importScripts(`${event.data.svelteUrl}/compiler.js`);
-			} catch (e) {
-				console.error('error in importScripts', e);
-
-				try {
-					await import(/* @vite-ignore */ `${event.data.svelteUrl}/compiler.js`);
-				} catch (e) {
-					console.error('error in await import', e);
-					const res = await fetch(`${event.data.svelteUrl}/compiler.js`);
-					const fn = new Function(await res.text());
-					fn();
-				}
-			}
+			const res = await fetch(`${event.data.svelteUrl}/compiler.js`);
+			const fn = new Function(await res.text());
+			fn();
 
 			fulfil_ready();
 			break;

--- a/packages/repl/src/lib/workers/compiler/index.js
+++ b/packages/repl/src/lib/workers/compiler/index.js
@@ -10,7 +10,8 @@ self.addEventListener('message', async (event) => {
 		case 'init':
 			try {
 				importScripts(`${event.data.svelteUrl}/compiler.js`);
-			} catch {
+			} catch (e) {
+				console.error('error in importScripts', e);
 				await import(/* @vite-ignore */ `${event.data.svelteUrl}/compiler.js`);
 			}
 

--- a/sites/svelte.dev/package.json
+++ b/sites/svelte.dev/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "node scripts/update.js && svelte-kit dev",
-		"build": "node scripts/update.js && svelte-kit build",
+		"build": "node scripts/update.js && svelte-kit build && node scripts/create-middleware",
 		"update": "node scripts/update.js --force=true",
 		"preview": "svelte-kit preview",
 		"start": "node build",

--- a/sites/svelte.dev/scripts/create-middleware.js
+++ b/sites/svelte.dev/scripts/create-middleware.js
@@ -1,0 +1,42 @@
+// this generates some middleware that will set COOP/COEP headers
+// so that webcontainers work. ideally there'd be a more idiomatic
+// way to do this, but it'll do in the meantime
+
+import fs from 'fs';
+
+if (!fs.existsSync('.vercel/output/config.json')) {
+	throw new Error('.vercel/output does not exist');
+}
+
+const fn = `
+export default function middleware(_request, _event) {
+	const response = new Response();
+
+	response.headers.set('cross-origin-opener-policy', 'same-origin');
+	response.headers.set('cross-origin-embedder-policy', 'require-corp');
+	response.headers.set('cross-origin-resource-policy', 'cross-origin');
+	response.headers.set('x-middleware-next', '1');
+
+	return response;
+}
+`;
+
+const config = JSON.parse(fs.readFileSync('.vercel/output/config.json', 'utf-8'));
+config.routes.unshift({
+	src: '/(.*)',
+	middlewarePath: '_middleware',
+	continue: true
+});
+fs.writeFileSync('.vercel/output/config.json', JSON.stringify(config));
+
+fs.mkdirSync('.vercel/output/functions/_middleware.func');
+
+fs.writeFileSync(
+	'.vercel/output/functions/_middleware.func/.vc-config.json',
+	JSON.stringify({
+		runtime: 'edge',
+		entrypoint: 'index.js'
+	})
+);
+
+fs.writeFileSync('.vercel/output/functions/_middleware.func/index.js', fn);

--- a/sites/svelte.dev/scripts/create-middleware.js
+++ b/sites/svelte.dev/scripts/create-middleware.js
@@ -1,6 +1,6 @@
-// this generates some middleware that will set COOP/COEP headers
-// so that webcontainers work. ideally there'd be a more idiomatic
-// way to do this, but it'll do in the meantime
+// this generates some middleware that will set COEP/CORP headers
+// so that it's possible to embed svelte.dev on a site with
+// cross-origin isolation enabled
 
 import fs from 'fs';
 

--- a/sites/svelte.dev/src/hooks.js
+++ b/sites/svelte.dev/src/hooks.js
@@ -10,7 +10,12 @@ export async function handle({ event, resolve }) {
 	event.locals.cookies = cookie.parse(event.request.headers.get('cookie') || '');
 	event.locals.user = await session.read(event.locals.cookies.sid);
 
-	return await resolve(event);
+	const response = await resolve(event);
+
+	response.headers.set('cross-origin-embedder-policy', 'require-corp');
+	response.headers.set('cross-origin-resource-policy', 'cross-origin');
+
+	return response;
 }
 
 /** @type {import('@sveltejs/kit').GetSession} */


### PR DESCRIPTION
This is super niche, but I'm preparing a talk that embeds a site in an `<iframe>` that requires cross-origin isolation. In order to do so, the talk itself must be cross-origin-isolated.

But making the talk cross-origin-isolated means it's no longer possible to embed svelte.dev in an `<iframe>`, which I _also_ need to do. The solution is very specific and probably useless to 7,899,999,999 of the 7.9 billion people on the planet, but it's also (as far as I can tell) harmless.

The CORP and COEP headers are needed together to allow this site to be embedded elsewhere. The COEP header prevents _this_ site from embedding other cross-origin resources unless _they_ have the correct headers; for that reason we need to add some Vercel middleware that applies COEP/COOP/CORP headers to static assets including our web workers.

Something about this combination caused Firefox to trip up over `importScripts`, so I replaced that block with a `new Function`, which works everywhere (since Svelte and Rollup are just setting globals in that context).

Will understand if other maintainers 👎 this, but it would help me out of a jam