### PR TITLE
Changed the vite syntax to reflect vite docs.

### DIFF
--- a/sites/svelte.dev/src/routes/index.svelte
+++ b/sites/svelte.dev/src/routes/index.svelte
@@ -84,7 +84,7 @@
 		</div>
 
 		<div slot="how">
-			<pre><code>npm init vite my-app -- <a href="https://github.com/vitejs/vite/tree/main/packages/create-vite/template-svelte" style="user-select: initial;"
+			<pre><code>npm create vite my-app -- <a href="https://github.com/vitejs/vite/tree/main/packages/create-vite/template-svelte" style="user-select: initial;"
 					>--template svelte</a>
 cd my-app
 npm install


### PR DESCRIPTION
The vite docs recommend the usage of npm create as a way to bootstrap via vite. Making this change to maintain consistency between vite docs and svelte quick start