### PR TITLE
Fixes REPL targeting bug in Safari

### DIFF
--- a/sites/svelte.dev/src/routes/repl/[id]/index.svelte
+++ b/sites/svelte.dev/src/routes/repl/[id]/index.svelte
@@ -133,6 +133,7 @@
 	}
 	.repl-outer :global(.tab-content.visible) {
 		visibility: visible;
+		z-index: 1;
 	}
 
 	.zen-mode {


### PR DESCRIPTION
In Safari, right clicking an element in the REPL preview and selecting "Inspect Element" would yield the wrong iframe as the target.

The correct iframe (.tab-content) has a class of .visible to display it, simple fix is to add `z-index: 1` to the declaration