### PR TITLE
Fix `h4` anchors positioning in `site-kit` package

### DIFF
--- a/packages/site-kit/src/lib/docs/Main.svelte
+++ b/packages/site-kit/src/lib/docs/Main.svelte
@@ -206,7 +206,7 @@
 	}
 
 	.content :global(h4::before) {
-		display: block;
+		display: inline;
 		content: ' ';
 		block-size: var(--nav-h);
 		margin-block-start: calc(-1 * var(--nav-h));


### PR DESCRIPTION
The anchors in h4 are wrongly positioned, this is a small PR that fixes this problem by changing `display: block` to `display: inline`.

Here's a small comparison:

| svelte.dev  |  PR  |
| ------------------- | ------------------- |
|  ![image](https://user-images.githubusercontent.com/61414485/176435791-adb81b1c-5803-42cd-bc9d-ae9ae2449b2b.png) |  ![image](https://user-images.githubusercontent.com/61414485/176435872-89d5ba7f-8913-40c7-ba50-199f46ec9171.png) |

