### PR TITLE
fix REPL pane resizing

### DIFF
--- a/packages/repl/src/lib/SplitPane.svelte
+++ b/packages/repl/src/lib/SplitPane.svelte
@@ -24,7 +24,7 @@
 	let dragging = false;
 
 	function setPos(event) {
-		const { top, left, width, height } = refs.container.getBoundingClientRect();
+		const { top, left } = refs.container.getBoundingClientRect();
 
 		const px = type === 'vertical' ? event.clientY - top : event.clientX - left;
 

--- a/packages/repl/src/lib/SplitPane.svelte
+++ b/packages/repl/src/lib/SplitPane.svelte
@@ -1,6 +1,6 @@
 <script>
 	import * as yootils from 'yootils';
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
 
 	const dispatch = createEventDispatcher();
 
@@ -24,7 +24,7 @@
 	let dragging = false;
 
 	function setPos(event) {
-		const { top, left } = refs.container.getBoundingClientRect();
+		const { top, left, width, height } = refs.container.getBoundingClientRect();
 
 		const px = type === 'vertical' ? event.clientY - top : event.clientX - left;
 
@@ -98,6 +98,14 @@
 		};
 	}
 
+	onMount(() => {
+		// fixes a weird firefox bug
+		setTimeout(() => {
+			w = refs.container.clientWidth;
+			h = refs.container.clientHeight;
+		}, 0);
+	});
+
 	$: side = type === 'horizontal' ? 'left' : 'top';
 	$: dimension = type === 'horizontal' ? 'width' : 'height';
 </script>
@@ -147,6 +155,7 @@
 		width: 100%;
 		height: 100%;
 		background: rgba(255, 255, 255, 0.01);
+		z-index: 99999;
 	}
 
 	.divider {


### PR DESCRIPTION
i'm surprised we didn't get yelled at more for this. the REPL is kinda busted at the moment — Firefox doesn't know how big the container should be, and the `<SplitPane>` component keeps losing track of the mouse as soon as it touches the iframe:

https://user-images.githubusercontent.com/1162160/179646274-ba71e685-985e-4e12-81b2-6afdea92eb9d.mov

This fixes both.