### PR TITLE
Fix incorrect directory name in code example

### DIFF
--- a/sites/svelte.dev/src/routes/index.svelte
+++ b/sites/svelte.dev/src/routes/index.svelte
@@ -84,7 +84,7 @@
 		</div>
 
 		<div slot="how">
-			<pre><code>npm create vite@latest my-app -- <a href="https://github.com/vitejs/vite/tree/main/packages/create-vite/template-svelte" style="user-select: initial;"
+			<pre><code>npm create vite@latest myapp -- <a href="https://github.com/vitejs/vite/tree/main/packages/create-vite/template-svelte" style="user-select: initial;"
 					>--template svelte</a>
 cd my-app
 npm install

--- a/sites/svelte.dev/src/routes/index.svelte
+++ b/sites/svelte.dev/src/routes/index.svelte
@@ -84,7 +84,7 @@
 		</div>
 
 		<div slot="how">
-			<pre><code>npm create vite@latest myapp -- <a href="https://github.com/vitejs/vite/tree/main/packages/create-vite/template-svelte" style="user-select: initial;"
+			<pre><code>npm create vite@latest my-app -- <a href="https://github.com/vitejs/vite/tree/main/packages/create-vite/template-svelte" style="user-select: initial;"
 					>--template svelte</a>
 cd my-app
 npm install

--- a/sites/svelte.dev/src/routes/index.svelte
+++ b/sites/svelte.dev/src/routes/index.svelte
@@ -86,7 +86,7 @@
 		<div slot="how">
 			<pre><code>npm create vite@latest myapp -- <a href="https://github.com/vitejs/vite/tree/main/packages/create-vite/template-svelte" style="user-select: initial;"
 					>--template svelte</a>
-cd my-app
+cd myapp
 npm install
 npm run dev
 			</code></pre>


### PR DESCRIPTION
Code example creates a directory named `myapp` but then tries to `cd` into `my-app`. Originally changed in 0cbac1aa4885d21d29b50ce607353e8f07103651.