### PR TITLE
setup redirects

### DIFF
--- a/sites/svelte.dev/src/hooks.server.js
+++ b/sites/svelte.dev/src/hooks.server.js
@@ -1,9 +1,0 @@
-export const handle = async ({ event, resolve }) => {
-	if (event.url.pathname === '/blog/the-easiest-way-to-get-started') {
-		return Response.redirect(`${event.url.origin}/docs/introduction`, 308);
-	}
-	if (event.url.pathname === '/roadmap') {
-		return Response.redirect('https://docs.google.com/document/d/1IA9Z5rcIm_KRxvh_L42d2NDdYRHZ72MfszhyJrsmf5A', 307);
-	}
-	return await resolve(event);
-}

--- a/sites/svelte.dev/src/hooks.server.js
+++ b/sites/svelte.dev/src/hooks.server.js
@@ -1,0 +1,9 @@
+export const handle = async ({ event, resolve }) => {
+	if (event.url.pathname === '/blog/the-easiest-way-to-get-started') {
+		return Response.redirect(`${event.url.origin}/docs/introduction`, 308);
+	}
+	if (event.url.pathname === '/roadmap') {
+		return Response.redirect('https://docs.google.com/document/d/1IA9Z5rcIm_KRxvh_L42d2NDdYRHZ72MfszhyJrsmf5A', 307);
+	}
+	return await resolve(event);
+}

--- a/sites/svelte.dev/src/routes/blog/the-easiest-way-to-get-started/+page.js
+++ b/sites/svelte.dev/src/routes/blog/the-easiest-way-to-get-started/+page.js
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load({ event }) {
+  throw redirect(308, `${event.url.origin}/docs/introduction`);
+}

--- a/sites/svelte.dev/src/routes/roadmap/+page.js
+++ b/sites/svelte.dev/src/routes/roadmap/+page.js
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load({ event }) {
+  throw redirect(307, 'https://docs.google.com/document/d/1IA9Z5rcIm_KRxvh_L42d2NDdYRHZ72MfszhyJrsmf5A');
+}


### PR DESCRIPTION
Serve svelte.dev/roadmap so we can easily host it elsewhere in the future if we wish

The getting started page now lives at https://kit.svelte.dev/docs/introduction#getting-started