### PR TITLE
Decouple site-kit from SvelteKit

### DIFF
--- a/packages/site-kit/src/lib/components/NavItem.svelte
+++ b/packages/site-kit/src/lib/components/NavItem.svelte
@@ -1,16 +1,15 @@
 <script>
-	import { page } from '$app/stores';
-
 	export let href = null;
 	export let external = null;
 	export let title = null;
+	export let selected = undefined;
 </script>
 
 {#if external}
 	<li><a href={external} {title} rel="external"><slot /></a></li>
 {:else}
 	<li>
-		<a aria-current={$page.url.pathname.startsWith(href) ? true : undefined} {href} {title}>
+		<a aria-current={selected} {href} {title}>
 			<slot />
 		</a>
 	</li>

--- a/packages/site-kit/src/lib/docs/Main.svelte
+++ b/packages/site-kit/src/lib/docs/Main.svelte
@@ -1,5 +1,4 @@
 <script>
-	import { page } from '$app/stores';
 	import { getFragment, onNavigate } from '../utils/navigation';
 	import '../code.css';
 
@@ -15,7 +14,7 @@
 			if (heading.nodeName.startsWith('H') && !heading.querySelector('a.anchor')) {
 				const a = document.createElement('a');
 				a.className = 'anchor';
-				a.href = `${$page.url.pathname}#${heading.id}`;
+				a.href = `${window.location.pathname}#${heading.id}`;
 				const span = document.createElement('span');
 				span.className = 'visually-hidden';
 				span.innerHTML = 'permalink';
@@ -45,7 +44,7 @@
 					const { id } = heading;
 
 					if (id !== last_id) {
-						path = `${$page.url.pathname}#${id}`;
+						path = `${window.location.pathname}#${id}`;
 						last_id = id;
 					}
 
@@ -53,7 +52,7 @@
 				}
 			}
 
-			path = $page.url.pathname;
+			path = window.location.pathname;
 		};
 
 		window.addEventListener('scroll', onscroll, true);


### PR DESCRIPTION
I'd like to make this a best practice for the following reasons:
- it makes it easier to use with tools like Vitest and Storybook
- it removes a circular dependency between `site-kit` and `kit.svelte.dev`
- it makes it possible to use the package on a non-SvelteKit site
- i'd guess that accessing `window.location.pathname` results in a slightly smaller compiler output than accessing `$app/stores`. you can't do this everywhere, but we can here in `onMount`
- I'm guessing it'd have the potential to make Rollup compilation faster though you might not notice unless you had a fairly large project and I'm not familiar enough with the Rollup internals to know if it works the way I imagine it might