### PR TITLE
update repl package to work with latest sveltekit

### DIFF
--- a/packages/repl/jsconfig.json
+++ b/packages/repl/jsconfig.json
@@ -1,4 +1,5 @@
 {
+	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
 		"baseUrl": ".",
 		"paths": {

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -2,10 +2,10 @@
 	"name": "@sveltejs/repl",
 	"version": "0.0.1",
 	"scripts": {
-		"dev": "svelte-kit dev",
-		"build": "svelte-kit build",
-		"package": "svelte-kit package",
-		"preview": "svelte-kit preview",
+		"dev": "vite dev",
+		"build": "vite build",
+		"package": "svelte-package",
+		"preview": "vite preview",
 		"lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
 		"format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. ."
 	},

--- a/packages/repl/src/app.html
+++ b/packages/repl/src/app.html
@@ -3,11 +3,11 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="description" content="" />
-		<link rel="icon" href="/favicon.png" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%svelte.head%
+		%sveltekit.head%
 	</head>
 	<body>
-		<div id="svelte">%svelte.body%</div>
+		<div id="svelte">%sveltekit.body%</div>
 	</body>
 </html>

--- a/packages/repl/src/routes/+page.svelte
+++ b/packages/repl/src/routes/+page.svelte
@@ -3,7 +3,6 @@
 	import { onMount } from 'svelte';
 	import '@sveltejs/site-kit/base.css';
 	import '@sveltejs/site-kit/code.css';
-	import { browser } from '$app/environment';
 
 	let repl;
 
@@ -28,9 +27,7 @@
 </script>
 
 <main>
-	{#if browser}
-		<Repl bind:this={repl} showModified showAst />
-	{/if}
+	<Repl bind:this={repl} showAst />
 </main>
 
 <style>

--- a/packages/repl/src/routes/+page.svelte
+++ b/packages/repl/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte';
 	import '@sveltejs/site-kit/base.css';
 	import '@sveltejs/site-kit/code.css';
+	import { browser } from '$app/environment';
 
 	let repl;
 
@@ -27,7 +28,9 @@
 </script>
 
 <main>
-	<Repl bind:this={repl} showAst />
+	{#if browser}
+		<Repl bind:this={repl} showModified showAst />
+	{/if}
 </main>
 
 <style>

--- a/packages/repl/svelte.config.js
+++ b/packages/repl/svelte.config.js
@@ -1,29 +1,11 @@
-import path from 'path';
 import adapter from '@sveltejs/adapter-auto';
 
 /** @type {import('@sveltejs/kit').Config} */
-const config = {
+export default {
 	kit: {
-		adapter: adapter(),
-
-		package: {
-			exports: (file) => file === 'index.js'
-		},
-
-		vite: {
-			resolve: {
-				alias: {
-					'@sveltejs/repl': path.resolve('src/lib'),
-					'@sveltejs/site-kit': path.resolve('../site-kit/src/lib')
-				}
-			},
-			server: {
-				fs: {
-					strict: false
-				}
-			}
-		}
-	}
+		adapter: adapter()
+	},
+    package: {
+        exports: (file) => file === 'index.js'
+    }
 };
-
-export default config;

--- a/packages/repl/svelte.config.js
+++ b/packages/repl/svelte.config.js
@@ -5,7 +5,7 @@ export default {
 	kit: {
 		adapter: adapter()
 	},
-    package: {
-        exports: (file) => file === 'index.js'
-    }
+	package: {
+		exports: (file) => file === 'index.js'
+	}
 };

--- a/packages/repl/vite.config.js
+++ b/packages/repl/vite.config.js
@@ -1,0 +1,20 @@
+import path from 'path';
+import { sveltekit } from '@sveltejs/kit/vite';
+
+/** @type {import('vite').UserConfig} */
+const config = {
+	plugins: [sveltekit()],
+	resolve: {
+		alias: {
+			'@sveltejs/repl': path.resolve('src/lib'),
+			'@sveltejs/site-kit': path.resolve('../site-kit/src/lib')
+		}
+	},
+	server: {
+		fs: {
+			strict: false
+		}
+	}
+};
+
+export default config;


### PR DESCRIPTION
updates the repl sveltekit app to work with the new routing system https://github.com/sveltejs/kit/discussions/5748 and new packaging command. https://github.com/sveltejs/kit/pull/5730
note: does not affect the actual library `packages/repl/src/lib`