### PR TITLE
fix importing from other cdns

### DIFF
--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -145,8 +145,8 @@ async function get_bundle(uid, mode, cache, lookup) {
 			// importing from a URL
 			if (importee.startsWith('http:') || importee.startsWith('https:')) return importee;
 
-			// importing from (probably) unpkg
-			if (importee.startsWith('.')) {
+			// importing from a cdn
+			if (importee.startsWith('.') || importee.startsWith('/')) {
 				const url = new URL(importee, importer).href;
 				self.postMessage({ type: 'status', uid, message: `resolving ${url}` });
 


### PR DESCRIPTION
Fixes imports from other CDNs like esm.sh and jspm.dev

URL for testing: https://esm.sh/@vueuse/core@9.5.0/