### PR TITLE
prerender RSS feed

### DIFF
--- a/sites/svelte.dev/src/routes/blog/rss.xml/+server.js
+++ b/sites/svelte.dev/src/routes/blog/rss.xml/+server.js
@@ -1,5 +1,7 @@
 import { get_index } from '$lib/server/markdown';
 
+export const prerender = true;
+
 const months = ',Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec'.split(',');
 
 function formatPubdate(str) {


### PR DESCRIPTION
closes #415. this was a victim of #413 — the RSS feed is now powered by the filesystem rather than an API, which means it needs to be prerendered. But that's a good thing, because regenerating it per request is silly