### PR TITLE
feat: add support for `exports` field to REPL

### DIFF
--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -30,6 +30,7 @@
 		"acorn": "^8.8.2",
 		"codemirror": "5.65.1",
 		"estree-walker": "^3.0.3",
+		"resolve.exports": "^2.0.0",
 		"svelte-json-tree": "^1.0.0",
 		"yootils": "^0.3.1"
 	},

--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -110,6 +110,7 @@ function has_loopGuardTimeout_feature() {
 async function get_bundle(uid, mode, cache, lookup) {
 	let bundle;
 
+	/** A set of package names (without subpaths) to include in pkg.devDependencies when downloading an app */
 	const imports = new Set();
 	const warnings = [];
 	const all_warnings = [];

--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -179,7 +179,7 @@ async function get_bundle(uid, mode, cache, lookup) {
 							exprots_resolver(pkg, importee, { browser: true, conditions: ['production'] }) ??
 							legacy_resolver(pkg, {
 								browser: importee,
-								fields: [['svelte', 'browser', 'module', 'main']]
+								fields: ['svelte', 'browser', 'module', 'main']
 							});
 
 						if (resolved_id === false) {

--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -175,7 +175,7 @@ async function get_bundle(uid, mode, cache, lookup) {
 						const pkg = JSON.parse(pkg_json);
 
 						/** @type {string | false | undefined} */
-						const resolvedId =
+						const resolved_id =
 							exprotsResolver(pkg, importee, { browser: true, conditions: ['production'] }) ??
 							legacyResolver(pkg, {
 								browser: importee,

--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -176,7 +176,7 @@ async function get_bundle(uid, mode, cache, lookup) {
 
 						/** @type {string | false | undefined} */
 						const resolved_id =
-							exprots_resolver(pkg, importee, { browser: true, conditions: ['production'] }) ??
+							exprots_resolver(pkg, importee, { browser: true, conditions: ['svelte', 'production'] }) ??
 							legacy_resolver(pkg, {
 								browser: importee,
 								fields: ['svelte', 'browser', 'module', 'main']

--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -1,5 +1,5 @@
 import { rollup } from '@rollup/browser';
-import { exports as exprotsResolver, legacy as legacyResolver } from 'resolve.exports';
+import { exports as exprots_resolver, legacy as legacy_resolver } from 'resolve.exports';
 import { sleep } from 'yootils';
 import commonjs from './plugins/commonjs.js';
 import glsl from './plugins/glsl.js';
@@ -176,17 +176,17 @@ async function get_bundle(uid, mode, cache, lookup) {
 
 						/** @type {string | false | undefined} */
 						const resolved_id =
-							exprotsResolver(pkg, importee, { browser: true, conditions: ['production'] }) ??
-							legacyResolver(pkg, {
+							exprots_resolver(pkg, importee, { browser: true, conditions: ['production'] }) ??
+							legacy_resolver(pkg, {
 								browser: importee,
 								fields: [['svelte', 'browser', 'module', 'main']]
 							});
 
-						if (resolvedId === false) {
+						if (resolved_id === false) {
 							// TODO: Output an error to the user that the package author doesn't want the user to import this path
-						} else if (resolvedId != null) {
+						} else if (resolved_id != null) {
 							const url = pkg_url.replace(/\/package\.json$/, '');
-							return new URL(resolvedId, `${url}/`).href;
+							return new URL(resolved_id, `${url}/`).href;
 						}
 					} catch (err) {
 						// ignore

--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -1,5 +1,5 @@
 import { rollup } from '@rollup/browser';
-import { exports as exports_resolver, legacy as legacy_resolver } from 'resolve.exports';
+import * as resolve from 'resolve.exports';
 import { sleep } from 'yootils';
 import commonjs from './plugins/commonjs.js';
 import glsl from './plugins/glsl.js';
@@ -107,6 +107,59 @@ function has_loopGuardTimeout_feature() {
 	return compare_to_version(3, 14, 0) >= 0;
 }
 
+async function resolve_from_pkg(pkg, subpath) {
+	// match legacy Rollup logic — pkg.svelte takes priority over pkg.exports
+	if (typeof pkg.svelte === 'string' && subpath === '.') {
+		return pkg.svelte;
+	}
+
+	// modern
+	if (pkg.exports) {
+		try {
+			const [resolved] = resolve.exports(pkg, subpath, {
+				browser: true,
+				conditions: ['svelte', 'production']
+			});
+
+			return resolved;
+		} catch {
+			throw `no matched export path was found in "${pkg_name}/package.json"`;
+		}
+	}
+
+	// legacy
+	if (subpath === '.') {
+		const resolved_id = resolve.legacy(pkg, {
+			fields: ['browser', 'module', 'main']
+		});
+
+		if (!resolved_id) {
+			// last ditch — try to match index.js/index.mjs
+			for (const index_file of ['index.mjs', 'index.js']) {
+				try {
+					const indexUrl = new URL(index_file, `${pkg_url_base}/`).href;
+					return await follow_redirects(indexUrl, uid);
+				} catch {
+					// maybe the next option will be successful
+				}
+			}
+
+			throw `could not find entry point in "${pkg_name}/package.json"`;
+		}
+
+		return resolved_id;
+	}
+
+	if (typeof pkg.browser === 'object') {
+		// this will either return `pkg.browser[subpath]` or `subpath`
+		return resolve.legacy(pkg, {
+			browser: subpath
+		});
+	}
+
+	return subpath;
+}
+
 async function get_bundle(uid, mode, cache, lookup) {
 	let bundle;
 
@@ -157,98 +210,44 @@ async function get_bundle(uid, mode, cache, lookup) {
 				// fetch from unpkg
 				self.postMessage({ type: 'status', uid, message: `resolving ${importee}` });
 
-				const importee_package_name_match = /^(@[^/]+\/)?[^/]+/.exec(importee);
-
-				if (importee_package_name_match) {
-					const importee_package_name = importee_package_name_match[0];
-
-					if (importer in lookup) {
-						imports.add(importee_package_name);
-					}
-
-					const fetch_package_info = async () => {
-						try {
-							const pkg_url = await follow_redirects(
-								`${packagesUrl}/${importee_package_name}/package.json`,
-								uid
-							);
-							const pkg_json = (await fetch_if_uncached(pkg_url, uid)).body;
-							const pkg = JSON.parse(pkg_json);
-
-							const pkg_url_base = pkg_url.replace(/\/package\.json$/, '');
-
-							return {
-								pkg,
-								pkg_url_base
-							};
-						} catch (_e) {
-							throw new Error(
-								`Error fetching "${importee_package_name}" from unpkg. Does the package exist?`
-							);
-						}
-					};
-
-					const { pkg, pkg_url_base } = await fetch_package_info();
-
-					const invalid_import = (reason) => new Error(`Cannot import "${importee}": ${reason}.`);
-
-					/** @type {string | false | undefined} */
-					let resolved_id;
-
-					try {
-						const result = exports_resolver(pkg, importee, {
-							browser: true,
-							conditions: ['svelte', 'production']
-						});
-
-						if (result) {
-							resolved_id = result[0];
-						}
-					} catch {
-						throw invalid_import(
-							`no matched export path was found in "${importee_package_name}/package.json"`
-						);
-					}
-
-					if (resolved_id == null) {
-						resolved_id = legacy_resolver(pkg, {
-							browser: importee,
-							fields: ['svelte', 'browser', 'module', 'main']
-						});
-
-						if (resolved_id === false) {
-							throw invalid_import(
-								`forbidden by "browser" field in "${importee_package_name}/package.json"`
-							);
-						}
-					}
-
-					if (resolved_id == null) {
-						// If not resolved, there is still hope by the NPM standards to resolve it
-						//  to the file `./index.{mjs|js}`, if exists.
-						if (importee_package_name === importee) {
-							const index_files = ['mjs', 'js'].map((ext) => `index.${ext}`);
-
-							// Return the first one that doesn't throw, if any
-							for (const index_file of index_files) {
-								try {
-									const indexUrl = new URL(index_file, `${pkg_url_base}/`).href;
-									return await follow_redirects(indexUrl, uid);
-								} catch {
-									// maybe the next option will be successful
-								}
-							}
-
-							throw invalid_import(
-								`could not find entry point in "${importee_package_name}/package.json"`
-							);
-						}
-					} else {
-						return new URL(resolved_id, `${pkg_url_base}/`).href;
-					}
+				const match = /^((?:@[^/]+\/)?[^/]+)(\/.+)?$/.exec(importee);
+				if (!match) {
+					throw new Error(`Invalid import "${importee}"`);
 				}
 
-				return await follow_redirects(`${packagesUrl}/${importee}`, uid);
+				const pkg_name = match[1];
+				const subpath = `.${match[2] ?? ''}`;
+
+				// if this was imported by one of our files, add it to the `imports` set
+				if (importer in lookup) {
+					imports.add(pkg_name);
+				}
+
+				const fetch_package_info = async () => {
+					try {
+						const pkg_url = await follow_redirects(`${packagesUrl}/${pkg_name}/package.json`, uid);
+						const pkg_json = (await fetch_if_uncached(pkg_url, uid)).body;
+						const pkg = JSON.parse(pkg_json);
+
+						const pkg_url_base = pkg_url.replace(/\/package\.json$/, '');
+
+						return {
+							pkg,
+							pkg_url_base
+						};
+					} catch (_e) {
+						throw new Error(`Error fetching "${pkg_name}" from unpkg. Does the package exist?`);
+					}
+				};
+
+				const { pkg, pkg_url_base } = await fetch_package_info();
+
+				try {
+					const resolved_id = await resolve_from_pkg(pkg, subpath);
+					return new URL(resolved_id, `${pkg_url_base}/`).href;
+				} catch (reason) {
+					throw new Error(`Cannot import "${importee}": ${reason}.`);
+				}
 			}
 		},
 		async load(resolved) {

--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -1,5 +1,5 @@
 import { rollup } from '@rollup/browser';
-import { exports as exprots_resolver, legacy as legacy_resolver } from 'resolve.exports';
+import { exports as exports_resolver, legacy as legacy_resolver } from 'resolve.exports';
 import { sleep } from 'yootils';
 import commonjs from './plugins/commonjs.js';
 import glsl from './plugins/glsl.js';
@@ -176,7 +176,7 @@ async function get_bundle(uid, mode, cache, lookup) {
 
 						/** @type {string | false | undefined} */
 						const resolved_id =
-							exprots_resolver(pkg, importee, { browser: true, conditions: ['svelte', 'production'] }) ??
+							exports_resolver(pkg, importee, { browser: true, conditions: ['svelte', 'production'] }) ??
 							legacy_resolver(pkg, {
 								browser: importee,
 								fields: ['svelte', 'browser', 'module', 'main']

--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -157,11 +157,10 @@ async function get_bundle(uid, mode, cache, lookup) {
 				self.postMessage({ type: 'status', uid, message: `resolving ${importee}` });
 
 				const importee_package_name_match = /^(@[^/]+\/)?[^/]+/.exec(importee);
-				const importee_package_name = importee_package_name_match
-					? importee_package_name_match[0]
-					: null;
 
-				if (importee_package_name != null) {
+				if (importee_package_name_match) {
+					const importee_package_name = importee_package_name_match[0];
+					
 					if (importer in lookup) {
 						imports.add(importee_package_name);
 					}

--- a/packages/repl/src/lib/workers/bundler/index.js
+++ b/packages/repl/src/lib/workers/bundler/index.js
@@ -181,15 +181,15 @@ async function get_bundle(uid, mode, cache, lookup) {
 								pkg_url_base
 							};
 						} catch (_e) {
-							throw `Error during fetching the NPM package "${importee_package_name}". Does this package exist?`;
+							throw new Error(
+								`Error fetching "${importee_package_name}" from unpkg. Does the package exist?`
+							);
 						}
 					};
 
 					const { pkg, pkg_url_base } = await fetch_package_info();
 
-					const throwInvalidImportError = (reason) => {
-						throw `Cannot import "${importee}": ${reason}.`;
-					};
+					const invalid_import = (reason) => new Error(`Cannot import "${importee}": ${reason}.`);
 
 					/** @type {string | false | undefined} */
 					let resolved_id;
@@ -204,7 +204,7 @@ async function get_bundle(uid, mode, cache, lookup) {
 							resolved_id = result[0];
 						}
 					} catch {
-						throw throwInvalidImportError(
+						throw invalid_import(
 							`no matched export path was found in "${importee_package_name}/package.json"`
 						);
 					}
@@ -216,8 +216,8 @@ async function get_bundle(uid, mode, cache, lookup) {
 						});
 
 						if (resolved_id === false) {
-							throwInvalidImportError(
-								`this path is forbidden to be loaded in the browser, stated by the "browser" field in "${importee_package_name}/package.json"`
+							throw invalid_import(
+								`forbidden by "browser" field in "${importee_package_name}/package.json"`
 							);
 						}
 					}
@@ -238,11 +238,8 @@ async function get_bundle(uid, mode, cache, lookup) {
 								}
 							}
 
-							throwInvalidImportError(
-								`no main entry point were found in "${importee_package_name}/package.json", ` +
-									`nor the files ${index_files
-										.map((index_file) => `"${importee_package_name}/${index_file}"`)
-										.join(' and ')}`
+							throw invalid_import(
+								`could not find entry point in "${importee_package_name}/package.json"`
 							);
 						}
 					} else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ importers:
       estree-walker: ^3.0.3
       prettier: ^2.8.4
       prettier-plugin-svelte: ^2.9.0
+      resolve.exports: ^2.0.0
       svelte: ^3.55.1
       svelte-json-tree: ^1.0.0
       svelte2tsx: ^0.6.1
@@ -34,6 +35,7 @@ importers:
       acorn: 8.8.2
       codemirror: 5.65.1
       estree-walker: 3.0.3
+      resolve.exports: 2.0.0
       svelte-json-tree: 1.0.0
       yootils: 0.3.1
     devDependencies:
@@ -109,6 +111,7 @@ importers:
       prettier-plugin-svelte: ^2.6.0
       prism-svelte: ^0.5.0
       prismjs: ^1.29.0
+      resolve.exports: ^2.0.0
       satori: ^0.0.44
       satori-html: ^0.3.2
       shelljs: ^0.8.5
@@ -139,6 +142,7 @@ importers:
       prettier-plugin-svelte: 2.9.0_jrsxveqmsx2uadbqiuq74wlc4u
       prism-svelte: 0.5.0
       prismjs: 1.29.0
+      resolve.exports: 2.0.0
       satori: 0.0.44
       satori-html: 0.3.2
       shelljs: 0.8.5
@@ -3549,6 +3553,10 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
     dev: true
+
+  /resolve.exports/2.0.0:
+    resolution: {integrity: sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg==}
+    engines: {node: '>=10'}
 
   /resolve/1.22.1:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,7 +111,6 @@ importers:
       prettier-plugin-svelte: ^2.6.0
       prism-svelte: ^0.5.0
       prismjs: ^1.29.0
-      resolve.exports: ^2.0.0
       satori: ^0.0.44
       satori-html: ^0.3.2
       shelljs: ^0.8.5
@@ -142,7 +141,6 @@ importers:
       prettier-plugin-svelte: 2.9.0_jrsxveqmsx2uadbqiuq74wlc4u
       prism-svelte: 0.5.0
       prismjs: 1.29.0
-      resolve.exports: 2.0.0
       satori: 0.0.44
       satori-html: 0.3.2
       shelljs: 0.8.5
@@ -3557,6 +3555,7 @@ packages:
   /resolve.exports/2.0.0:
     resolution: {integrity: sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg==}
     engines: {node: '>=10'}
+    dev: false
 
   /resolve/1.22.1:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}


### PR DESCRIPTION
Finally fixes #134.
Based on https://github.com/sveltejs/sites/issues/134#issuecomment-995449952 and https://github.com/sveltejs/sites/issues/134#issuecomment-1444393511.

~Still on draft since~ I don't know how to report the errors in importing to the user, see the two "TODO"s.

Related context: https://github.com/benmccann/esm-env/pull/2#issuecomment-1444437790