### PR TITLE
chore: add backquotes to svelte:document in April newsletter 

### DIFF
--- a/sites/svelte.dev/content/blog/2023-04-01-whats-new-in-svelte-april-2023.md
+++ b/sites/svelte.dev/content/blog/2023-04-01-whats-new-in-svelte-april-2023.md
@@ -24,7 +24,7 @@ Now let's jump into this month's changes...
 - Inputs in a `bind:group` will clear when their value is set to `undefined` (**3.56.0**, [#8214](https://github.com/sveltejs/svelte/issues/8214))
 - `<input>` values will now persist when swapping elements with spread attributes in an `{#each}` block (**3.56.0**, [#7578](https://github.com/sveltejs/svelte/issues/7578))
 - Better warnings across the board - from `noreferrer` to `aria` rules (**3.56.0**)
-- Add <svelte:document> (**3.57.0**, [#3310](https://github.com/sveltejs/svelte/issues/3310))
+- Add `<svelte:document>` (**3.57.0**, [#3310](https://github.com/sveltejs/svelte/issues/3310))
 - The `style:` directive will now take precedence over a `style=` attribute (**3.57.0**, [#7475](https://github.com/sveltejs/svelte/issues/7475))
 - CSS units are now supported in the `fly` and `blur` transitions (**3.57.0**, [#7623](https://github.com/sveltejs/svelte/pull/7623), [Docs](https://svelte.dev/docs#run-time-svelte-transition))
 


### PR DESCRIPTION
`<svelte:document>` is being rendered as an anchor, so I add backquotes to fix that.

<img width="678" alt="image" src="https://user-images.githubusercontent.com/29677552/229505046-87e11efa-ce93-4143-b3d1-4db200db986b.png">
