### PR TITLE
add support for css option 'none'

### DIFF
--- a/packages/repl/src/lib/Output/CompilerOptions.svelte
+++ b/packages/repl/src/lib/Output/CompilerOptions.svelte
@@ -24,11 +24,18 @@
 		<span class="boolean">{$compile_options.dev}</span>,
 	</label>
 
-	<label class="option">
+	<div class="option">
 		<span class="key">css:</span>
-		<Checkbox bind:checked={$compile_options.css} />
-		<span class="boolean">{$compile_options.css}</span>,
-	</label>
+
+		<input id="injected-input" type="radio" bind:group={$compile_options.css} value="injected" />
+		<label for="injected-input"><span class="string">"injected"</span></label>
+
+		<input id="external-input" type="radio" bind:group={$compile_options.css} value="external" />
+		<label for="external-input"><span class="string">"external"</span></label>
+
+		<input id="none-input" type="radio" bind:group={$compile_options.css} value="none" />
+		<label for="none-input"><span class="string">"none"</span>,</label>
+	</div>
 
 	<label class="option">
 		<span class="key">hydratable:</span>

--- a/packages/repl/src/lib/index.svelte
+++ b/packages/repl/src/lib/index.svelte
@@ -92,7 +92,7 @@
 	const compile_options = writable({
 		generate: 'dom',
 		dev: false,
-		css: false,
+		css: 'injected',
 		hydratable: false,
 		customElement: false,
 		immutable: false,


### PR DESCRIPTION
Svelte compiler changed css option to `'external' | 'injected' | 'none'` since 3.53. ([changelog](https://github.com/sveltejs/svelte/blob/master/CHANGELOG.md#3530))

This PR just updates the REPL UI to support the new option.