### PR TITLE
Display full post contents in RSS

### DIFF
--- a/sites/svelte.dev/src/routes/blog/rss.xml/+server.js
+++ b/sites/svelte.dev/src/routes/blog/rss.xml/+server.js
@@ -43,7 +43,7 @@ const get_rss = (posts) =>
 		<item>
 			<title>${escapeHTML(post.title)}</title>
 			<link>https://svelte.dev/blog/${post.slug}</link>
-			<description>${escapeHTML(post.description)}</description>
+			<description><![CDATA[${post.content}]]></description>
 			<pubDate>${formatPubdate(post.date)}</pubDate>
 		</item>
 	`


### PR DESCRIPTION
Instead of only rendering the description, render full post contents in RSS so announcements can be read in RSS readers.

I had a hard time setting up the monorepo locally, I was going to verify the changes on the Vercel preview but need to be authorized first.