### PR TITLE
(fix) loading files from repl json broke the REPL upon renaming

### DIFF
--- a/.changeset/proud-wombats-buy.md
+++ b/.changeset/proud-wombats-buy.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/repl': patch
+---
+
+(fix) loading files in editor state map upon loading

--- a/packages/repl/src/lib/Repl.svelte
+++ b/packages/repl/src/lib/Repl.svelte
@@ -1,7 +1,8 @@
 <script>
+	import { EditorState } from '@codemirror/state';
 	import { SplitPane } from '@rich_harris/svelte-split-pane';
 	import { BROWSER } from 'esm-env';
-	import { createEventDispatcher, tick } from 'svelte';
+	import { createEventDispatcher } from 'svelte';
 	import { derived, writable } from 'svelte/store';
 	import Bundler from './Bundler.js';
 	import ComponentSelector from './Input/ComponentSelector.svelte';
@@ -9,8 +10,7 @@
 	import InputOutputToggle from './InputOutputToggle.svelte';
 	import Output from './Output/Output.svelte';
 	import { set_repl_context } from './context.js';
-	import { get_full_filename, sleep } from './utils.js';
-	import { EditorState } from '@codemirror/state';
+	import { get_full_filename } from './utils.js';
 
 	export let packagesUrl = 'https://unpkg.com';
 	export let svelteUrl = `${packagesUrl}/svelte`;

--- a/packages/repl/src/lib/Repl.svelte
+++ b/packages/repl/src/lib/Repl.svelte
@@ -55,22 +55,13 @@
 		// with a new state for each file containing the source as docs
 		// this allows the editor to behave correctly when renaming a tab
 		// after having loaded the files externally
-		data.files.forEach((file) => {
-			EDITOR_STATE_MAP.set(
-				get_full_filename(file),
-				EditorState.create({
-					doc: file.source
-				}).toJSON()
-			);
-		});
+		populate_editor_state();
+
+		dispatch('change', { files: $files });
 	}
 
 	export function markSaved() {
 		$files = $files.map((val) => ({ ...val, modified: false }));
-
-		// if (!$selected) return;
-
-		// const current = $files.find(val => get_full_filename(val) === $selected_name).modified = false;
 	}
 
 	/** @param {{ files: import('./types').File[], css?: string }} data */
@@ -94,6 +85,8 @@
 			$module_editor?.clearEditorState();
 		}
 
+		populate_editor_state();
+
 		dispatch('change', { files: $files });
 	}
 
@@ -104,7 +97,7 @@
 	 * @typedef {import('./types').ReplContext} ReplContext
 	 */
 
-	/** @type {import('svelte/types/compiler').CompileOptions} */
+	/** @type {import('svelte/compiler').CompileOptions} */
 	const DEFAULT_COMPILE_OPTIONS = {
 		generate: 'dom',
 		dev: false,
@@ -257,6 +250,17 @@
 		$module_editor?.clearEditorState();
 
 		EDITOR_STATE_MAP.clear();
+	}
+
+	function populate_editor_state() {
+		for (const file of $files) {
+			EDITOR_STATE_MAP.set(
+				get_full_filename(file),
+				EditorState.create({
+					doc: file.source
+				}).toJSON()
+			);
+		}
 	}
 
 	$: if ($output && $selected) {

--- a/packages/repl/src/lib/types.d.ts
+++ b/packages/repl/src/lib/types.d.ts
@@ -1,7 +1,7 @@
 import type { EditorState } from '@codemirror/state';
 import { OutputChunk } from '@rollup/browser';
 import type { Readable, Writable } from 'svelte/store';
-import { CompileOptions } from 'svelte/types/compiler';
+import { CompileOptions } from 'svelte/compiler';
 
 export type Lang = 'js' | 'svelte' | 'json' | 'md' | 'css' | (string & Record<never, never>);
 

--- a/packages/repl/src/routes/+page.svelte
+++ b/packages/repl/src/routes/+page.svelte
@@ -15,11 +15,17 @@
 					source:
 						`<scr` +
 						`ipt>
+    import B from './B.svelte';
 	let name = 'world';
 </scr` +
 						`ipt>
 
 <h1>Hello {name}!</h1>`
+				},
+				{
+					name: 'B',
+					type: 'svelte',
+					source: `B`
 				}
 			]
 		});


### PR DESCRIPTION
When loading the files from a saved REPL renaming a file broke the REPL because selecting a new tab was storing the state from App.svelte for the newly selected file in the EDITOR_STATE_MAP. Given that the state includes the document itself after renaming the file the editor restored the state with the wrong doc.

See this REPL as an example, trying to rename ItemTypeOne substitute the content of ItemTypeOne.svelte with the one from App.svelte
https://svelte.dev/repl/d9d167fa8ded478ba4dea62257d75a10?version=3.8.0