### PR TITLE
(fix) avoid automatic newline when renaming/creating a file

### DIFF
--- a/.changeset/fresh-days-know.md
+++ b/.changeset/fresh-days-know.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/repl': patch
+---
+
+(fix) avoid automatic newline when renaming/creating a file

--- a/packages/repl/src/lib/Input/ComponentSelector.svelte
+++ b/packages/repl/src/lib/Input/ComponentSelector.svelte
@@ -244,8 +244,14 @@
 								bind:value={input_value}
 								on:focus={select_input}
 								on:blur={close_edit}
-								on:keydown={(e) =>
-									e.key === 'Enter' && !is_file_name_used(editing_file) && e.currentTarget.blur()}
+								on:keydown={(e) => {
+									if (e.key === 'Enter') {
+										e.preventDefault();
+										if (!is_file_name_used(editing_file)) {
+											e.currentTarget.blur();
+										}
+									}
+								}}
 								class:duplicate={is_file_name_used(editing_file)}
 							/>
 						{/if}


### PR DESCRIPTION
This fixes the automatic newline that get's added when renamig/creating a file