### PR TITLE
Fix attribute deletion

### DIFF
--- a/.changeset/sweet-pianos-sniff.md
+++ b/.changeset/sweet-pianos-sniff.md
@@ -2,4 +2,4 @@
 '@sveltejs/repl': patch
 ---
 
-manage diagnostics asyncronously
+manage diagnostics asyncronously with linter

--- a/.changeset/sweet-pianos-sniff.md
+++ b/.changeset/sweet-pianos-sniff.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/repl': patch
+---
+
+manage diagnostics asyncronously

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -73,7 +73,7 @@
 		"@codemirror/view": "^6.14.0",
 		"@jridgewell/sourcemap-codec": "^1.4.15",
 		"@lezer/highlight": "^1.1.6",
-		"@neocodemirror/svelte": "0.0.14",
+		"@neocodemirror/svelte": "0.0.15",
 		"@replit/codemirror-lang-svelte": "^6.0.0",
 		"@rich_harris/svelte-split-pane": "^1.1.1",
 		"@rollup/browser": "^3.25.3",

--- a/packages/repl/src/lib/CodeMirror.svelte
+++ b/packages/repl/src/lib/CodeMirror.svelte
@@ -4,7 +4,6 @@
 
 <script>
 	import { historyField } from '@codemirror/commands';
-	import { codeFolding } from '@codemirror/language';
 	import { EditorState, Range, StateEffect, StateEffectType, StateField } from '@codemirror/state';
 	import { Decoration, EditorView } from '@codemirror/view';
 	import { codemirror, withCodemirrorInstance } from '@neocodemirror/svelte';
@@ -12,13 +11,12 @@
 	import { writable } from 'svelte/store';
 	import Message from './Message.svelte';
 	import { svelteTheme } from './theme.js';
-	import { linter } from '@codemirror/lint';
 
 	/** @type {import('./types').StartOrEnd | null} */
 	export let errorLoc = null;
 
-	/** @type {()=>Promise<import('@codemirror/lint').Diagnostic[]>} */
-	export let diagnostics = async () => [];
+	/** @type {import('@codemirror/lint').LintSource>} */
+	export let diagnostics;
 
 	export let readonly = false;
 	export let tab = true;
@@ -231,8 +229,9 @@
 			css: () => import('@codemirror/lang-css').then((m) => m.css()),
 			svelte: () => import('@replit/codemirror-lang-svelte').then((m) => m.svelte())
 		},
+		lint: diagnostics,
 		autocomplete,
-		extensions: [codeFolding(), watcher, linter(diagnostics)],
+		extensions: [watcher],
 		instanceStore: cmInstance
 	}}
 	on:codemirror:textChange={({ detail: value }) => {

--- a/packages/repl/src/lib/CodeMirror.svelte
+++ b/packages/repl/src/lib/CodeMirror.svelte
@@ -12,12 +12,13 @@
 	import { writable } from 'svelte/store';
 	import Message from './Message.svelte';
 	import { svelteTheme } from './theme.js';
+	import { linter } from '@codemirror/lint';
 
 	/** @type {import('./types').StartOrEnd | null} */
 	export let errorLoc = null;
 
-	/** @type {import('@codemirror/lint').Diagnostic[]} */
-	export let diagnostics = [];
+	/** @type {()=>Promise<import('@codemirror/lint').Diagnostic[]>} */
+	export let diagnostics = async () => [];
 
 	export let readonly = false;
 	export let tab = true;
@@ -231,8 +232,7 @@
 			svelte: () => import('@replit/codemirror-lang-svelte').then((m) => m.svelte())
 		},
 		autocomplete,
-		extensions: [codeFolding(), watcher],
-		diagnostics,
+		extensions: [codeFolding(), watcher, linter(diagnostics)],
 		instanceStore: cmInstance
 	}}
 	on:codemirror:textChange={({ detail: value }) => {

--- a/packages/repl/src/lib/Input/ModuleEditor.svelte
+++ b/packages/repl/src/lib/Input/ModuleEditor.svelte
@@ -34,8 +34,6 @@
 		}
 	}
 
-	$: max_length = $selected?.source.length ?? 0;
-
 	async function diagnostics() {
 		await $bundling;
 		return $selected && error_file === get_full_filename($selected)

--- a/packages/repl/src/lib/Input/ModuleEditor.svelte
+++ b/packages/repl/src/lib/Input/ModuleEditor.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { get_repl_context } from '$lib/context.js';
-	import { get_full_filename } from '$lib/utils.js';
+	import { clamp, get_full_filename } from '$lib/utils.js';
 	import CodeMirror from '../CodeMirror.svelte';
 	import Message from '../Message.svelte';
 
@@ -29,11 +29,13 @@
 	$: if ($bundle) {
 		error = $bundle?.error;
 		warnings = $bundle?.warnings ?? [];
-
+		console.log({ error, warnings });
 		if (error || warnings.length > 1) {
 			error_file = error?.filename ?? warnings[0]?.filename;
 		}
 	}
+
+	$: max_length = $selected?.source.length ?? 0;
 
 	$: diagnostics =
 		$selected && error_file === get_full_filename($selected)
@@ -41,21 +43,22 @@
 					...(error
 						? [
 								{
-									from: error.start.character,
-									to: error.end.character,
+									from: clamp(0, max_length, error.start.character),
+									to: clamp(0, max_length, error.end.character),
 									severity: 'error',
 									message: error.message
 								}
 						  ]
 						: []),
 					...warnings.map((warning) => ({
-						from: warning.start.character,
-						to: warning.end.character,
+						from: clamp(0, max_length, warning.start.character),
+						to: clamp(0, max_length, warning.end.character),
 						severity: 'warning',
 						message: warning.message
 					}))
 			  ])
 			: [];
+	$: console.log(diagnostics);
 </script>
 
 <div class="editor-wrapper">

--- a/packages/repl/src/lib/Repl.svelte
+++ b/packages/repl/src/lib/Repl.svelte
@@ -150,12 +150,16 @@
 	/** @type {ReplContext['bundler']} */
 	const bundler = writable(null);
 
+	/** @type {ReplContext['bundling']} */
+	const bundling = writable(new Promise(() => {}));
+
 	set_repl_context({
 		files,
 		selected_name,
 		selected,
 		bundle,
 		bundler,
+		bundling,
 		compile_options,
 		cursor_pos,
 		module_editor,
@@ -175,8 +179,13 @@
 	let current_token;
 	async function rebundle() {
 		const token = (current_token = Symbol());
+		let resolver = () => {};
+		$bundling = new Promise((resolve) => {
+			resolver = resolve;
+		});
 		const result = await $bundler?.bundle($files);
 		if (result && token === current_token) $bundle = result;
+		resolver();
 	}
 
 	let is_select_changing = false;

--- a/packages/repl/src/lib/types.d.ts
+++ b/packages/repl/src/lib/types.d.ts
@@ -54,6 +54,7 @@ export type ReplState = {
 	selected_name: string;
 	selected: File | null;
 	bundle: Bundle | null;
+	bundling: Promise<void>;
 	bundler: import('./Bundler').default | null;
 	compile_options: CompileOptions;
 	cursor_pos: number;
@@ -67,6 +68,7 @@ export type ReplContext = {
 	selected_name: Writable<ReplState['selected_name']>;
 	selected: Readable<ReplState['selected']>;
 	bundle: Writable<ReplState['bundle']>;
+	bundling: Writable<ReplState['bundling']>;
 	bundler: Writable<ReplState['bundler']>;
 	compile_options: Writable<ReplState['compile_options']>;
 	cursor_pos: Writable<ReplState['cursor_pos']>;

--- a/packages/repl/src/routes/+page.svelte
+++ b/packages/repl/src/routes/+page.svelte
@@ -15,17 +15,20 @@
 					source:
 						`<scr` +
 						`ipt>
-    import B from './B.svelte';
 	let name = 'world';
 </scr` +
 						`ipt>
 
-<h1>Hello {name}!</h1>`
+<h1>Hello {name}!</h1>
+
+<input type="button" on:click on:keypress value="press me"/>
+`
 				},
 				{
 					name: 'B',
 					type: 'svelte',
-					source: `B`
+					source: `<input type="button" on:click on:keypress value="press me"/>
+`
 				}
 			]
 		});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,31 +121,6 @@ importers:
         specifier: ^4.3.9
         version: 4.3.9
 
-  packages/site-kit:
-    dependencies:
-      golden-fleece:
-        specifier: ^1.0.9
-        version: 1.0.9
-    devDependencies:
-      '@sveltejs/kit':
-        specifier: ^1.0.0
-        version: 1.20.5(svelte@3.55.0)(vite@4.3.9)
-      '@sveltejs/package':
-        specifier: ^1.0.0
-        version: 1.0.0(svelte@3.55.0)(typescript@4.5.5)
-      svelte:
-        specifier: ^3.55.0
-        version: 3.55.0
-      svelte2tsx:
-        specifier: ^0.4.14
-        version: 0.4.14(svelte@3.55.0)(typescript@4.5.5)
-      typescript:
-        specifier: ^4.5.5
-        version: 4.5.5
-      vite:
-        specifier: ^4.0.1
-        version: 4.3.9
-
   sites/hn.svelte.dev:
     devDependencies:
       '@sveltejs/adapter-auto':
@@ -937,22 +912,6 @@ packages:
       vite: 4.3.9
     transitivePeerDependencies:
       - supports-color
-
-  /@sveltejs/package@1.0.0(svelte@3.55.0)(typescript@4.5.5):
-    resolution: {integrity: sha512-YTTzhbOtmyq342S3tTYRJ9QQntRlukWieP5gQmqTMxdn1Ztr93pzR9vLCZ0q/pV4sqmEllc70lHJX/iV5uEYEg==}
-    engines: {node: '>=16.14'}
-    hasBin: true
-    peerDependencies:
-      svelte: ^3.44.0
-    dependencies:
-      chokidar: 3.5.3
-      kleur: 4.1.5
-      sade: 1.8.1
-      svelte: 3.55.0
-      svelte2tsx: 0.5.23(svelte@3.55.0)(typescript@4.5.5)
-    transitivePeerDependencies:
-      - typescript
-    dev: true
 
   /@sveltejs/package@2.1.0(svelte@4.0.0)(typescript@5.1.3):
     resolution: {integrity: sha512-c6PLH9G2YLQ48kqrS2XX422BrLNABBstSiapamchVJaQnOTXyJmUR8KmoCCySnzVy3PiYL6jg12UnoPmjW3SwA==}
@@ -1815,10 +1774,6 @@ packages:
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
-
-  /golden-fleece@1.0.9:
-    resolution: {integrity: sha512-YSwLaGMOgSBx9roJlNLL12c+FRiw7VECphinc6mGucphc/ZxTHgdEz6gmJqH6NOzYEd/yr64hwjom5pZ+tJVpg==}
-    dev: false
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -3026,30 +2981,6 @@ packages:
       typescript: 5.1.3
     dev: true
 
-  /svelte2tsx@0.4.14(svelte@3.55.0)(typescript@4.5.5):
-    resolution: {integrity: sha512-udF0Z/DA98OfjPFBU1GBJRpYHEvsxA8ozwYVN08AOWMnQyxoSyWWlYspiq2m9xAjLo/pWnhec9z1d6jc9umqjA==}
-    peerDependencies:
-      svelte: ^3.24
-      typescript: ^4.1.2
-    dependencies:
-      dedent-js: 1.0.1
-      pascal-case: 3.1.2
-      svelte: 3.55.0
-      typescript: 4.5.5
-    dev: true
-
-  /svelte2tsx@0.5.23(svelte@3.55.0)(typescript@4.5.5):
-    resolution: {integrity: sha512-jYFnugTQRFmUpvLXPQrKzVYcW5ErT+0QCxg027Zx9BuvYefMZFuoBSTDYe7viPEFGrPPiLgT2m7f5n9khE7f7Q==}
-    peerDependencies:
-      svelte: ^3.24
-      typescript: ^4.1.2
-    dependencies:
-      dedent-js: 1.0.1
-      pascal-case: 3.1.2
-      svelte: 3.55.0
-      typescript: 4.5.5
-    dev: true
-
   /svelte2tsx@0.6.16(svelte@4.0.0)(typescript@5.1.3):
     resolution: {integrity: sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==}
     peerDependencies:
@@ -3152,12 +3083,6 @@ packages:
       call-bind: 1.0.2
       for-each: 0.3.3
       is-typed-array: 1.1.10
-    dev: true
-
-  /typescript@4.5.5:
-    resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
     dev: true
 
   /typescript@5.1.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^1.1.6
         version: 1.1.6
       '@neocodemirror/svelte':
-        specifier: 0.0.14
-        version: 0.0.14(@codemirror/autocomplete@6.8.1)(@codemirror/commands@6.2.4)(@codemirror/language@6.8.0)(@codemirror/lint@6.3.0)(@codemirror/search@6.5.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.0)
+        specifier: 0.0.15
+        version: 0.0.15(@codemirror/autocomplete@6.8.1)(@codemirror/commands@6.2.4)(@codemirror/language@6.8.0)(@codemirror/lint@6.3.0)(@codemirror/search@6.5.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.0)
       '@replit/codemirror-lang-svelte':
         specifier: ^6.0.0
         version: 6.0.0(@codemirror/autocomplete@6.8.1)(@codemirror/lang-css@6.2.0)(@codemirror/lang-html@6.4.5)(@codemirror/lang-javascript@6.1.9)(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.0)(@lezer/common@1.0.3)(@lezer/highlight@1.1.6)(@lezer/javascript@1.4.3)(@lezer/lr@1.3.7)
@@ -765,8 +765,8 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
-  /@neocodemirror/svelte@0.0.14(@codemirror/autocomplete@6.8.1)(@codemirror/commands@6.2.4)(@codemirror/language@6.8.0)(@codemirror/lint@6.3.0)(@codemirror/search@6.5.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.0):
-    resolution: {integrity: sha512-1kHm3IyBJJyRfItxodSbbLxBknYGKLahaiF6Vb/BcVfdwwFLLj4dvWKY78ep1YQIhDhklgBQztjRMuLn9tTTWg==}
+  /@neocodemirror/svelte@0.0.15(@codemirror/autocomplete@6.8.1)(@codemirror/commands@6.2.4)(@codemirror/language@6.8.0)(@codemirror/lint@6.3.0)(@codemirror/search@6.5.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.0):
+    resolution: {integrity: sha512-MCux+QCR40CboJu/TFwnqK7gYQ3fvtvHX8F/mk85DRH7vMoG3VDjJhqneAITX5IzohWKeP36hzcV+oHC2LYJqA==}
     peerDependencies:
       '@codemirror/autocomplete': ^6.7.1
       '@codemirror/commands': ^6.2.4


### PR DESCRIPTION
closes #496

This issue is due to the fact that the array of the diagnostics get's out of sync with the actual code for a brief moment. This usually it's not a huge problem because it get's recomputed moments later but it can be a problem when the error falls outside of the max length of source code.

To avoid this issue i've added a bundling promise inside the context that get's reassigned whenever a bundling process starts and resolved immediately after the new bundle has been assigned to the store. The diagnostic has also been transformed from an array that get's recalculated dynamically to an async function that awaits the bundling process. Finally instead of simply passing the diagnostics to neocodemirror we create a `linter ` extension passing the aforementioned async function. Codemirror will call and await this function at each modification.

A couple of points:

1. This means the diagnostics feel a bit more slow because it has to wait for the bundling to finish, however this is more correct since the diagnostics immediately reflect the actual source code.
2. This could also be "fixed" upstream in @PuruVJ @neocodemirror library, right now does work as intended but it uses setDiagnostics and it might be beneficial to use the linter extension instead to allow for async diagnostic calculation. So if @PuruVJ prefer to first upgrade @neocodemirror i can update this pr whenever he push a new release there.