### PR TITLE
Exclude HN site from search-engine indexing

### DIFF
--- a/sites/hn.svelte.dev/src/app.html
+++ b/sites/hn.svelte.dev/src/app.html
@@ -5,6 +5,7 @@
 		<meta name="description" content="A Hacker News clone built with SvelteKit" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="noindex,nofollow" />
 		<link rel="manifest" href="/manifest.json" />
 		<script>
 			try {


### PR DESCRIPTION
As mentioned in discord, having so many non-svelte results show up when searching for svelte related content can negatively impact people's ability to find the content they are looking for