### PR TITLE
fix(hn): correct CSS path for nested comments toggle

### DIFF
--- a/sites/hn.svelte.dev/src/routes/item/[id]/Comment.svelte
+++ b/sites/hn.svelte.dev/src/routes/item/[id]/Comment.svelte
@@ -54,7 +54,7 @@
 		background-size: 1em 1em;
 	}
 
-	.comment details[open] .meta-bar {
+	.comment details[open] > summary > .meta-bar {
 		background-image: url(./fold.svg);
 	}
 


### PR DESCRIPTION
Just realized CSS for recursive component not scoped, need to specify its toggle selector.