### PR TITLE
fix(repl): type indication for AstNode

### DIFF
--- a/packages/repl/src/lib/Output/AstNode.svelte
+++ b/packages/repl/src/lib/Output/AstNode.svelte
@@ -3,7 +3,7 @@
 	import { tick } from 'svelte';
 
 	export let key = '';
-	/** @type {import('svelte/types/compiler/interfaces').Ast} */
+	/** @type {import('svelte/types/compiler/interfaces').Ast & { type?: string }} */
 	export let value;
 	export let collapsed = true;
 	/** @type {import('svelte/types/compiler/interfaces').Ast[]} */
@@ -93,9 +93,15 @@
 	{#if is_collapsable}
 		{#if collapsed && !is_root}
 			<button class="preview" on:click={() => (collapsed = !collapsed)}>
+				{#if value.type}
+					<span class="token string">{value.type} </span>
+				{/if}
 				{preview_text}
 			</button>
 		{:else}
+			{#if value.type}
+				<span class="token string">{value.type} </span>
+			{/if}
 			<span>{is_ast_array ? '[' : '{'}</span>
 			<ul>
 				{#each Object.entries(value) as [k, v]}


### PR DESCRIPTION
This is a simple fix for the [issue#9205](https://github.com/sveltejs/svelte/issues/9205) I reported to Svelte.
<img width="331" alt="스크린샷 2023-09-19 133053" src="https://github.com/sveltejs/sites/assets/60684815/09612779-8a19-4717-b27d-07b9f6ed3209">
<img width="442" alt="스크린샷 2023-09-19 133039" src="https://github.com/sveltejs/sites/assets/60684815/137558f4-acd1-4a5f-8974-83056eba6cc6">