### PR TITLE
chore: list repo info in repl's `package.json`

### DIFF
--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -5,6 +5,11 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sveltejs/sites",
+		"directory": "packages/repl"
+	},
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"type": "module",


### PR DESCRIPTION
makes it easier to find your way here from npm