### PR TITLE
REPL: if file name input loses focus without contents changing, do nothing

### DIFF
--- a/packages/repl/src/lib/Input/ComponentSelector.svelte
+++ b/packages/repl/src/lib/Input/ComponentSelector.svelte
@@ -50,6 +50,11 @@
 
 		if (!edited_file) return;
 
+		if (edited_file.name === input_value) {
+			editing_name = null;
+			return;
+		}
+		
 		edited_file.name = match ? match[1] : input_value;
 
 		if (!$selected) return;


### PR DESCRIPTION
Currently, if a user clicks on the the name of a file in the REPL, they are able to edit it; but if they clicks away before typing anything, the contents of the file are deleted. (See https://github.com/sveltejs/sites/issues/552)

This PR prevents this from happening.