### PR TITLE
fix(hn): enable CSR on about page and prerender it

### DIFF
--- a/sites/hn.svelte.dev/src/routes/about/+page.js
+++ b/sites/hn.svelte.dev/src/routes/about/+page.js
@@ -1,1 +1,1 @@
-export const csr = false;
+export const prerender = true;


### PR DESCRIPTION
Allows for preloading to work on the about page.