### PR TITLE
chore: use `navigating` object property in condition

### DIFF
--- a/sites/hn.svelte.dev/src/routes/+error.svelte
+++ b/sites/hn.svelte.dev/src/routes/+error.svelte
@@ -1,10 +1,10 @@
 <script>
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 
 	const offline = typeof navigator !== 'undefined' && navigator.onLine === false;
 
-	const title = offline ? 'Offline' : $page.status;
-	const message = offline ? 'Find the internet and try again' : $page.error.message;
+	const title = offline ? 'Offline' : page.status;
+	const message = offline ? 'Find the internet and try again' : page.error?.message;
 </script>
 
 <svelte:head>

--- a/sites/hn.svelte.dev/src/routes/+layout.svelte
+++ b/sites/hn.svelte.dev/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { page, navigating } from '$app/stores';
+	import { page, navigating } from '$app/state';
 	import Nav from '$lib/Nav.svelte';
 	import PreloadingIndicator from '$lib/PreloadingIndicator.svelte';
 	import ThemeToggler from '$lib/ThemeToggler.svelte';
@@ -7,12 +7,12 @@
 
 	const { children } = $props();
 
-	const section = $derived($page.url.pathname.split('/')[1]);
+	const section = $derived(page.url.pathname.split('/')[1]);
 </script>
 
 <Nav {section} />
 
-{#if $navigating}
+{#if navigating.from}
 	<PreloadingIndicator />
 {/if}
 


### PR DESCRIPTION
Follow up to https://github.com/sveltejs/sites/pull/568
Since `navigating` is always an object, we check the truthiness of the object property instead, which can be `null` when there is no ongoing navigation.