### PR TITLE
add note to readme about new svelte.dev repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # sveltejs/sites
 
 Monorepo for [sites](sites) built with Svelte.
+
+# Note
+
+If you're looking for the main Svelte site, that no longer lives in this repositry. See [this repo](https://github.com/sveltejs/svelte.dev) instead.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Monorepo for [sites](sites) built with Svelte.
 
 # Note
 
-If you're looking for the main Svelte site, that no longer lives in this repositry. See [this repo](https://github.com/sveltejs/svelte.dev) instead.
+If you're looking for the main Svelte site, that no longer lives in this repository. See [the `sveltejs/svelte.dev` repo](https://github.com/sveltejs/svelte.dev) instead.


### PR DESCRIPTION
There was an issue for svelte.dev opened in this repo today. If we want to keep this repo around for the HN frontend, we really should be directing people to the proper repo in this repo's readme for pretty much every else they might want to be doing or suggesting. Besides opening this PR, I've also gone ahead and removed 'svelte.dev' as the website associated with this repo, and I've removed the description referring to this as the monorepo for sites in the Svelte ecosystem.