### PR TITLE
feat(hn): internal route for merging multiple remote fetches

### DIFF
--- a/sites/hn.svelte.dev/src/app.d.ts
+++ b/sites/hn.svelte.dev/src/app.d.ts
@@ -21,6 +21,7 @@ declare global {
 		kids?: number[];
 		score: number;
 		time: number;
+		text?: string;
 		title: string;
 		type: 'story';
 		url: string;

--- a/sites/hn.svelte.dev/src/routes/[list=category]/[page=numeric]/+page.ts
+++ b/sites/hn.svelte.dev/src/routes/[list=category]/[page=numeric]/+page.ts
@@ -1,27 +1,15 @@
-import type { PageLoad } from './$types';
 import { error } from '@sveltejs/kit';
-
-const BASE = 'https://hacker-news.firebaseio.com/v0/';
-const ITEMS_PER_PAGE = 30;
+import type { PageLoad } from './$types';
+import type { ResponseType } from './api/+server';
 
 export const load = (async ({ params, fetch }) => {
 	const list = params.list === 'jobs' ? 'job' : params.list;
 	const page = +params.page;
-	const offset = (page - 1) * ITEMS_PER_PAGE;
 
-	const itemIds: number[] = await fetch(`${BASE}${list}stories.json`).then((res) => res.json());
-	const relevantItemIds = itemIds.slice(offset, offset + ITEMS_PER_PAGE);
+	const res = await fetch(`/${params.list}/${params.page}/api`);
+	if (!res.ok) error(res.status, res.statusText);
 
-	if (relevantItemIds.length === 0) {
-		error(404, 'Page not found');
-	}
-
-	const items: (HNStory | HNJob | HNPoll | { type: 'null'; id: number })[] = await Promise.all(
-		relevantItemIds.map((id) =>
-			fetch(`${BASE}item/${id}.json`).then((res) => res.json() ?? { type: 'null', id })
-		)
-	);
-
-	const now = Date.now();
+	const items: ResponseType = await res.json();
+	const now = Date.now() / 1000;
 	return { list, page, items, now };
 }) satisfies PageLoad;

--- a/sites/hn.svelte.dev/src/routes/[list=category]/[page=numeric]/api/+server.ts
+++ b/sites/hn.svelte.dev/src/routes/[list=category]/[page=numeric]/api/+server.ts
@@ -21,14 +21,12 @@ export const GET = (async ({ params, fetch }) => {
 		error(404, 'Page not found');
 	}
 
-	// allow partial failure in fetch
-	const allStoriesSettled = await Promise.allSettled(
-		relevantItemIds.map((id) => fetch(`${FIRESTORE_BASE}item/${id}.json`))
-	);
-	// resolve failed fetches as null
 	const items: ResponseType = await Promise.all(
-		allStoriesSettled.map((res) =>
-			res.status === 'fulfilled' && res.value.ok ? res.value.json() : null
+		relevantItemIds.map((id) =>
+			fetch(`${FIRESTORE_BASE}item/${id}.json`).then(
+				// allow partial failure in fetch
+				(res) => (res.ok ? res.json() : { type: 'null', id })
+			)
 		)
 	);
 

--- a/sites/hn.svelte.dev/src/routes/[list=category]/[page=numeric]/api/+server.ts
+++ b/sites/hn.svelte.dev/src/routes/[list=category]/[page=numeric]/api/+server.ts
@@ -1,0 +1,40 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+const FIRESTORE_BASE = 'https://hacker-news.firebaseio.com/v0/' as const;
+const ITEMS_PER_PAGE = 30 as const;
+
+export type ResponseType = (HNStory | HNJob | HNPoll | { type: 'null'; id: number })[];
+export const GET = (async ({ params, fetch }) => {
+	const list = params.list === 'jobs' ? 'job' : params.list;
+	const page = +params.page;
+
+	const offset = (page - 1) * ITEMS_PER_PAGE;
+	const storyResponse = await fetch(`${FIRESTORE_BASE}${list}stories.json`);
+	if (!storyResponse.ok)
+		error(storyResponse.status, `Upstream Responded with ${storyResponse.statusText}`);
+
+	const itemIds: number[] = await storyResponse.json();
+	const relevantItemIds = itemIds.slice(offset, offset + ITEMS_PER_PAGE);
+
+	if (relevantItemIds.length === 0) {
+		error(404, 'Page not found');
+	}
+
+	// allow partial failure in fetch
+	const allStoriesSettled = await Promise.allSettled(
+		relevantItemIds.map((id) => fetch(`${FIRESTORE_BASE}item/${id}.json`))
+	);
+	// resolve failed fetches as null
+	const items: ResponseType = await Promise.all(
+		allStoriesSettled.map((res) =>
+			res.status === 'fulfilled' && res.value.ok ? res.value.json() : null
+		)
+	);
+
+	return json(items, {
+		headers: {
+			'Cache-Control': 'public, max-age=60, s-maxage=60'
+		}
+	});
+}) satisfies RequestHandler;

--- a/sites/hn.svelte.dev/src/routes/[list=category]/rss/+server.ts
+++ b/sites/hn.svelte.dev/src/routes/[list=category]/rss/+server.ts
@@ -1,4 +1,6 @@
+import { error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import type { ResponseType } from '../[page=numeric]/api/+server';
 
 const render = (
 	list: string,
@@ -33,19 +35,11 @@ const render = (
 </channel>
 </rss>`;
 
-const BASE = 'https://hacker-news.firebaseio.com/v0/';
-const ITEMS_PER_PAGE = 30;
-
 export const GET = (async ({ params, fetch }) => {
-	const list = params.list === 'jobs' ? 'job' : params.list;
-
-	const itemIds: number[] = await fetch(`${BASE}${list}stories.json`).then((r) => r.json());
-	const relevantItemIds = itemIds.slice(0, ITEMS_PER_PAGE);
-	const items: (HNStory | HNJob | HNPoll | { type: 'null'; id: number })[] = await Promise.all(
-		relevantItemIds.map((id) =>
-			fetch(`${BASE}item/${id}.json`).then((res) => res.json() ?? { type: 'null', id })
-		)
-	);
+	const res = await fetch(`/${params.list}/1/api`);
+	if (!res.ok) error(res.status, res.statusText);
+	const items: ResponseType = await res.json();
+	const { list } = params;
 
 	const feed = render(list, items);
 

--- a/sites/hn.svelte.dev/src/routes/item/[id=numeric]/+page.ts
+++ b/sites/hn.svelte.dev/src/routes/item/[id=numeric]/+page.ts
@@ -1,35 +1,12 @@
+import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
+import type { ResponseType } from './api/+server';
 
 export const load = (async ({ params, fetch }) => {
-	const [hnItem, algoliaItem]: [HNItem | null, AlgoliaItem] = await Promise.all([
-		fetch(`https://hacker-news.firebaseio.com/v0/item/${params.id}.json`).then((r) => r.json()),
-		fetch(`https://hn.algolia.com/api/v1/items/${params.id}`).then((r) => r.json())
-	]);
+	const res = await fetch(`/item/${params.id}/api`);
+	if (!res.ok) error(res.status, res.statusText);
+	const { algoliaItem, pollOptions }: ResponseType = await res.json();
 
-	// if hn available, use their top-level sort
-	if (hnItem) {
-		if ('kids' in hnItem && hnItem.kids) {
-			const { kids } = hnItem;
-			algoliaItem.children.sort((a, b) => {
-				const indexA = kids.indexOf(a.id);
-				const indexB = kids.indexOf(b.id);
-				return indexA - indexB;
-			});
-		}
-		if ('parts' in hnItem && hnItem.parts) {
-			algoliaItem.options = hnItem.parts;
-		}
-	}
-
-	let pollOptions: HNPollOption[] = [];
-	if (algoliaItem && algoliaItem.type === 'poll') {
-		pollOptions = await Promise.all(
-			algoliaItem.options.map((id) =>
-				fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`).then((r) => r.json())
-			)
-		);
-	}
-
-	const now = Date.now();
+	const now = Date.now() / 1000;
 	return { algoliaItem, pollOptions, now };
 }) satisfies PageLoad;

--- a/sites/hn.svelte.dev/src/routes/item/[id=numeric]/api/+server.ts
+++ b/sites/hn.svelte.dev/src/routes/item/[id=numeric]/api/+server.ts
@@ -1,0 +1,56 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+const FIRESTORE_BASE = 'https://hacker-news.firebaseio.com/v0/' as const;
+
+export type ResponseType = { algoliaItem: AlgoliaItem; pollOptions: HNPollOption[] };
+export const GET = (async ({ params, fetch }) => {
+	// HN fetch is allowed to fail
+	const [hnRes, algoliaRes] = await Promise.allSettled([
+		fetch(`${FIRESTORE_BASE}item/${params.id}.json`),
+		fetch(`https://hn.algolia.com/api/v1/items/${params.id}`)
+	]);
+	if (algoliaRes.status === 'rejected') error(500, 'Upstream failure');
+	if (!algoliaRes.value.ok) error(algoliaRes.value.status, algoliaRes.value.statusText);
+
+	const algoliaItem: AlgoliaItem = await algoliaRes.value.json();
+	const hnItem: HNItem | null =
+		hnRes.status === 'fulfilled' && hnRes.value.ok ? await hnRes.value.json() : null;
+
+	// if hn available, use their top-level sort
+	if (hnItem) {
+		// comment sort
+		if ('kids' in hnItem && typeof hnItem.kids !== 'undefined') {
+			const { kids } = hnItem;
+			algoliaItem.children.sort((a, b) => {
+				const indexA = kids.indexOf(a.id);
+				const indexB = kids.indexOf(b.id);
+				return indexA - indexB;
+			});
+		}
+		// poll item sort
+		if ('parts' in hnItem) {
+			algoliaItem.options = hnItem.parts;
+		}
+	}
+
+	let pollOptions: HNPollOption[] = [];
+	if (algoliaItem.type === 'poll') {
+		const pollsResponses = await Promise.all(
+			algoliaItem.options.map((id) => fetch(`${FIRESTORE_BASE}item/${id}.json`))
+		);
+		pollOptions = await Promise.all(pollsResponses.map((poll) => poll.json()));
+	}
+
+	return json(
+		{
+			algoliaItem,
+			pollOptions
+		} satisfies ResponseType,
+		{
+			headers: {
+				'Cache-Control': 'public, max-age=60, s-maxage=60'
+			}
+		}
+	);
+}) satisfies RequestHandler;

--- a/sites/hn.svelte.dev/src/routes/item/[id=numeric]/api/+server.ts
+++ b/sites/hn.svelte.dev/src/routes/item/[id=numeric]/api/+server.ts
@@ -10,8 +10,9 @@ export const GET = (async ({ params, fetch }) => {
 		fetch(`${FIRESTORE_BASE}item/${params.id}.json`),
 		fetch(`https://hn.algolia.com/api/v1/items/${params.id}`)
 	]);
-	if (algoliaRes.status === 'rejected') error(500, 'Upstream failure');
-	if (!algoliaRes.value.ok) error(algoliaRes.value.status, algoliaRes.value.statusText);
+	if (algoliaRes.status === 'rejected') error(500, 'Network failure');
+	if (!algoliaRes.value.ok)
+		error(algoliaRes.value.status, `Upstream Responded with ${algoliaRes.value.statusText}`);
 
 	const algoliaItem: AlgoliaItem = await algoliaRes.value.json();
 	const hnItem: HNItem | null =

--- a/sites/hn.svelte.dev/src/routes/user/[name]/+page.ts
+++ b/sites/hn.svelte.dev/src/routes/user/[name]/+page.ts
@@ -1,11 +1,12 @@
+import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types.js';
+import type { ResponseType } from './api/+server.js';
+
 export const csr = false;
-
 export const load = (async ({ params, fetch }) => {
-	const user: HNUser = await fetch(
-		`https://hacker-news.firebaseio.com/v0/user/${params.name}.json`
-	).then((r) => r.json());
-
-	const now = Date.now();
+	const res = await fetch(`/user/${params.name}/api`);
+	if (!res.ok) error(res.status, res.statusText);
+	const user: ResponseType = await res.json();
+	const now = Date.now() / 1000;
 	return { user, now };
 }) satisfies PageLoad;

--- a/sites/hn.svelte.dev/src/routes/user/[name]/api/+server.ts
+++ b/sites/hn.svelte.dev/src/routes/user/[name]/api/+server.ts
@@ -6,7 +6,7 @@ const FIRESTORE_BASE = 'https://hacker-news.firebaseio.com/v0/' as const;
 export type ResponseType = HNUser;
 export const GET = (async ({ params, fetch }) => {
 	const res = await fetch(`${FIRESTORE_BASE}user/${params.name}.json`);
-	if (!res.ok) error(500, 'Upstream failure');
+	if (!res.ok) error(res.status, `Upstream Responded with ${res.statusText}`);
 	const user: HNUser = await res.json();
 	return json(user satisfies ResponseType, {
 		headers: {

--- a/sites/hn.svelte.dev/src/routes/user/[name]/api/+server.ts
+++ b/sites/hn.svelte.dev/src/routes/user/[name]/api/+server.ts
@@ -1,0 +1,16 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+const FIRESTORE_BASE = 'https://hacker-news.firebaseio.com/v0/' as const;
+
+export type ResponseType = HNUser;
+export const GET = (async ({ params, fetch }) => {
+	const res = await fetch(`${FIRESTORE_BASE}user/${params.name}.json`);
+	if (!res.ok) error(500, 'Upstream failure');
+	const user: HNUser = await res.json();
+	return json(user satisfies ResponseType, {
+		headers: {
+			'Cache-Control': 'public, max-age=60, s-maxage=60'
+		}
+	});
+}) satisfies RequestHandler;


### PR DESCRIPTION
It turns out every page navigation was reloading the remote endpoint fetches.
Both Algolia and Firebase attach `no-cache` in their headers, although I'm not certain that's the root cause specifically.
Either way, it was enough of a problem that I added `[...route]/api` endpoints so that all such accesses appear as single fetches to the pages, which seems to have avoided the problem of over-fetching.
As a bonus, we get to declare our own cache control response headers.

Minor miscellaneous changes
- Actually divide millisecond epoch by 1000 (oops)
- Type fixes for HNItem
- Use `Promise.allSettled` instead of `Promise.all` where partial fetch failure is okay
- `/[list]/rss` uses the `/[list]/1/api` endpoint instead of duplicating the logic
